### PR TITLE
Add a script to replace /Users with nfs mount

### DIFF
--- a/aladdin.sh
+++ b/aladdin.sh
@@ -88,9 +88,11 @@ function check_or_start_minikube() {
     if ! minikube status | grep Running &> /dev/null; then
         echo "Starting minikube..."
         minikube start --memory 4096 &> /dev/null
-        if ! "$(minikube ssh -- "test -x /var/lib/boot2docker/bootlocal.sh && echo true || echo false")"; then
+        # Determine if we've installed our bootlocal.sh script to replace the vboxsf mounts with nfs mounts
+        if ! "$(minikube ssh -- "test -x /var/lib/boot2docker/bootlocal.sh && echo -n true || echo -n false")"; then
             echo "Installing NFS mounts from host..."
             scripts/install_nfs_mounts.sh
+            echo "NFS mounts installed"
         fi
         echo "Minikube started"
     fi

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -86,7 +86,7 @@ function check_and_handle_init() {
 # Start minikube if we need to
 function check_or_start_minikube() {
     if ! minikube status | grep Running &> /dev/null; then
-        echo "Starting minikube..."
+        echo "Starting minikube... (this will take a moment)"
         minikube start --memory 4096 &> /dev/null
         # Determine if we've installed our bootlocal.sh script to replace the vboxsf mounts with nfs mounts
         if ! "$(minikube ssh -- "test -x /var/lib/boot2docker/bootlocal.sh && echo -n true || echo -n false")"; then

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -54,7 +54,7 @@ function check_cluster_alias() {
 }
 
 function check_and_handle_init() {
-    # Check if we need to force initialization 
+    # Check if we need to force initialization
     local last_launched_file init_every current_time previous_run
     last_launched_file="$HOME/.infra/last_checked_${NAMESPACE}_${CLUSTER_CODE}"
     init_every=3600
@@ -85,9 +85,13 @@ function check_and_handle_init() {
 
 # Start minikube if we need to
 function check_or_start_minikube() {
-    if ! (  minikube status | grep Running &> /dev/null ); then
-        echo "Starting minikube... (~75 seconds)"
+    if ! minikube status | grep Running &> /dev/null; then
+        echo "Starting minikube..."
         minikube start --memory 4096 &> /dev/null
+        if ! "$(minikube ssh -- "test -x /var/lib/boot2docker/bootlocal.sh && echo true || echo false")"; then
+            echo "Installing NFS mounts from host..."
+            scripts/install_nfs_mounts.sh
+        fi
         echo "Minikube started"
     fi
 }

--- a/scripts/install_nfs_mounts.sh
+++ b/scripts/install_nfs_mounts.sh
@@ -1,41 +1,37 @@
 #!/usr/bin/env bash
 
+case "$OSTYPE" in
+    cygwin*)
+		export_dir="/cygdrive/c/Users"
+		mount_dir="/c/Users"
+		;;
+
+	*)
+		export_dir="/Users"
+		mount_dir="/Users"
+		;;
+esac
+
 read -r -d '' bootlocal <<EOF ||:
 #!/bin/sh
 
-# The future, that doesn't depend on Cygwin specialization
 sudo systemctl start nfs-client.target
-sudo mkdir -p /Users
-sudo busybox umount /Users 2>/dev/null
-sudo busybox mount -t nfs -o tcp,rw,hard,noacl,async,nolock 192.168.99.1:/Users /Users
+sudo mkdir -p ${mount_dir}
+sudo busybox umount ${mount_dir} 2>/dev/null
+sudo busybox mount -t nfs -o tcp,rw,hard,noacl,async,nolock 192.168.99.1:${export_dir} ${mount_dir}
 EOF
-
-if [[ "$OSTYPE" == "cygwin" ]]; then
-	# Replace the current Cygwin vboxfs mount for now, since I think pathnorm expects to find things here
-    read -r -d '' bootlocal <<-EOF ||:
-	$bootlocal
-
-	sudo mkdir -p /c/Users
-	sudo busybox umount /c/Users 2>/dev/null
-	sudo busybox mount -t nfs -o tcp,rw,hard,noacl,async,nolock 192.168.99.1:/Users /c/Users
-	EOF
-fi
 
 echo -e "\\nInstalling persistent start-up script: /var/lib/boot2docker/bootlocal.sh"
 minikube ssh -- "echo \"${bootlocal}\" | sudo tee /var/lib/boot2docker/bootlocal.sh >/dev/null"
 minikube ssh -- "sudo chmod +x /var/lib/boot2docker/bootlocal.sh && sync"
 
-echo -e "\\nRunning start-up script manually to nfs mount /Users directory"
+echo -e "\\nRunning start-up script manually to nfs mount ${mount_dir} directory"
 minikube ssh -- "/var/lib/boot2docker/bootlocal.sh"
 
 echo -e "\\nTesting mounts"
 echo "============="
-minikube ssh -- "mount | grep '/Users'"
+minikube ssh -- "mount | grep '${mount_dir}'"
 
-echo -e "\\nTesting directories"
-echo "== /Users ================="
-minikube ssh -- "ls -al /Users"
-if [[ "$OSTYPE" == "cygwin" ]]; then
-    echo -e "\\n== /c/Users ================="
-    minikube ssh -- "ls -al /c/Users"
-fi
+echo -e "\\nTesting directory"
+echo "== ${mount_dir} ================="
+minikube ssh -- "ls -al ${mount_dir}"

--- a/scripts/install_nfs_mounts.sh
+++ b/scripts/install_nfs_mounts.sh
@@ -2,14 +2,14 @@
 
 case "$OSTYPE" in
     cygwin*)
-		export_dir="/cygdrive/c/Users"
-		mount_dir="/c/Users"
-		;;
+        export_dir="/cygdrive/c/Users"
+        mount_dir="/c/Users"
+        ;;
 
-	*)
-		export_dir="/Users"
-		mount_dir="/Users"
-		;;
+    *)
+        export_dir="/Users"
+        mount_dir="/Users"
+        ;;
 esac
 
 read -r -d '' bootlocal <<EOF ||:

--- a/scripts/install_nfs_mounts.sh
+++ b/scripts/install_nfs_mounts.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+read -r -d '' bootlocal <<EOF ||:
+#!/bin/sh
+
+# The future, that doesn't depend on Cygwin specialization
+sudo systemctl start nfs-client.target
+sudo mkdir -p /Users
+sudo busybox umount /Users 2>/dev/null
+sudo busybox mount -t nfs -o tcp,rw,hard,noacl,async,nolock 192.168.99.1:/Users /Users
+
+# Replace the current Cygwin vboxfs mount for now, since I think pathnorm expects to find things here
+sudo mkdir -p /c/Users
+sudo busybox umount /c/Users 2>/dev/null
+sudo busybox mount -t nfs -o tcp,rw,hard,noacl,async,nolock 192.168.99.1:/Users /c/Users
+EOF
+
+echo -e "\\nInstalling persistent start-up script: /var/lib/boot2docker/bootlocal.sh"
+minikube ssh -- "echo \"${bootlocal}\" | sudo tee /var/lib/boot2docker/bootlocal.sh >/dev/null"
+minikube ssh -- "sudo chmod +x /var/lib/boot2docker/bootlocal.sh && sync"
+
+echo -e "\\nRunning start-up script manually to nfs mount /Users directory"
+minikube ssh -- "/var/lib/boot2docker/bootlocal.sh"
+
+echo -e "\\nTesting mounts"
+echo "============="
+minikube ssh -- "mount | grep '/Users'"
+
+echo -e "\\nTesting directories"
+echo "== /Users ================="
+minikube ssh -- "ls -al /Users"
+echo -e "\\n== /c/Users ================="
+minikube ssh -- "ls -al /c/Users"


### PR DESCRIPTION
Aladdin uses minikube for local development which is a VirtualBox-based VM. Internally it mounts your `/Users` (or `/cygdrive/c/Users` for Cygwin users) directory to the root of the minikube filesystem. We have discovered that the `vboxsf` mounts are not as performant as NFS mounts and furthermore are not as reliable when it comes to detecting file changes made from the host. To address this, we replace the `vboxsf` mounts within minikube with NFS mounts. 
