### PR TITLE
Various improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine:latest
 
-RUN apk -Uuv \
-    add \
+RUN apk add --no-cache \
     bash \
     bash-completion \
     bats \
@@ -14,8 +13,7 @@ RUN apk -Uuv \
     openssh-client \
     python3 \
     ncurses \
-    vim \
-	&& rm /var/cache/apk/*
+    vim
 
 WORKDIR /root/aladdin
 COPY ./commands/python/requirements.txt ./commands/python/requirements.txt

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Aladdin uses minikube for local development which is a VirtualBox-based VM. Inte
     1. **Windows** You should install Cygwin and the `unfsd` package
         * Take care when configuring the `unfsd` package as it can inadvertently remove login capabilities for your active user account.
         * Be sure to add firewall exceptions for the installed services (/usr/sbin/unfsd & /usr/sbin/rpcbind).
-1. Add entries to your `/etc/hosts` file
+1. Add entries to your `/etc/exports` file
     1. **macOS**
     ```
     echo "/Users -alldirs -mapall="$(id -u)":"$(id -g)" $(minikube ip)" | sudo tee -a /etc/exports

--- a/aladdin-container.sh
+++ b/aladdin-container.sh
@@ -85,6 +85,11 @@ function environment_init() {
     echo "CLUSTER_CODE = $CLUSTER_CODE"
     echo "NAMESPACE = $NAMESPACE"
 
+    # Copy our .ssh directory over. This is a special case due to
+    # SSH permision and ownership checks on the ~/.ssh files.
+    rm -rf $HOME/.ssh
+    cp -r $HOME/_ssh $HOME/.ssh
+
     # Kops uses AWS_PROFILE instead of AWS_DEFAULT_PROFILE
     export AWS_PROFILE="$AWS_DEFAULT_PROFILE"
 
@@ -112,7 +117,6 @@ function environment_init() {
             _replace_aws_secret || true
             $PY_MAIN namespace-init --force
         fi
-
     fi
 
     echo "END ENVIRONMENT CONFIGURATION==============================================="

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -266,11 +266,11 @@ while [[ $# -gt 0 ]]; do
             NAMESPACE="$2"
             shift # past argument
         ;;
-        -i|--image)
+        --image)
             IMAGE="$2"
             shift # past argument
         ;;
-        --init)
+        -i|--init)
             INIT=true
         ;;
         --dev)

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -224,7 +224,7 @@ function enter_docker_container() {
         FLAGS+="t"
     fi
 
-    local aladdin_image="$(jq -r '.aladdin.repo' "$ALADDIN_CONFIG_FILE"):$(jq -r '.aladdin.tag' "$ALADDIN_CONFIG_FILE")"
+    local aladdin_image="${IMAGE:-"$(jq -r '.aladdin.repo' "$ALADDIN_CONFIG_FILE"):$(jq -r '.aladdin.tag' "$ALADDIN_CONFIG_FILE")"}"
 
     docker run $FLAGS \
         `# Environment` \
@@ -240,7 +240,7 @@ function enter_docker_container() {
         -e "command=$command" \
         `# Mount host credentials` \
         -v "$(pathnorm ~/.aws):/root/.aws" \
-        -v "$(pathnorm ~/.ssh):/root/.ssh" \
+        -v "$(pathnorm ~/.ssh):/root/_ssh" \
         -v "$(pathnorm ~/.kube):/root/.kube_local" \
         -v "$(pathnorm ~/.aladdin):/root/.aladdin" \
         -v "$(pathnorm $ALADDIN_CONFIG_DIR):/root/aladdin-config" \
@@ -264,6 +264,10 @@ while [[ $# -gt 0 ]]; do
         ;;
         -n|--namespace)
             NAMESPACE="$2"
+            shift # past argument
+        ;;
+        -i|--image)
+            IMAGE="$2"
             shift # past argument
         ;;
         --init)

--- a/commands/python/command/deploy.py
+++ b/commands/python/command/deploy.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import logging
+import sys
 import tempfile
 from arg_tools import add_namespace_argument
 from cluster_rules import cluster_rules
@@ -56,7 +57,7 @@ def deploy(project, git_ref, namespace, dry_run=False, force=False, force_helm=F
             logging.error(f'You are deploying hash {git_ref} which does not match branch '
                           f'{cr.check_branch} on cluster {cr.cluster_name} for project '
                           f'{project}... exiting')
-            return
+            sys.exit(1)
 
         helm.pull_package(project, pr, git_ref, tmpdirname)
 

--- a/commands/python/main.py
+++ b/commands/python/main.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
     subparsers = parser.add_subparsers(help='aladdin subcommands')
     subcommands = [
         build,
-        cluster_init, \
+        cluster_init,
         cmd,
         connect,
         deploy,
@@ -77,10 +77,11 @@ if __name__ == '__main__':
     # Add optional aladdin wide arguments for better help visibility
     parser.add_argument('--cluster', '-c', help='The cluster name you want to interact with')
     parser.add_argument('--namespace', '-n', help='The namespace name you want to interact with')
-    parser.add_argument('--init', action='store_true',
+    parser.add_argument('-i', '--init', action='store_true',
                         help='Force initialization logic')
     parser.add_argument('--dev', action='store_true',
                         help='Mount host\'s aladdin directory onto aladdin container')
+    parser.add_argument('--image', help='Use the specified aladdin image (if building it yourself')
     parser.add_argument('--skip-prompts', action='store_true',
                     help='Skip confirmation prompts during command execution')
     parser.add_argument('--non-terminal', action='store_true',


### PR DESCRIPTION
* Add the `-i` shorthand for the `--init` command-line option 
* Add the `--image` command-line option to allow one to specify the aladdin image to use for
  aladdin commands
* Avoid the need for `chmod 6000` on our host's `.ssh/config` file by mounting the hosts `~/.ssh`
  directory at `/root/_ssh` and copying the directory to `/root/.ssh` when the container starts.
  This way the ownership is transferred to the `root` user.
* Exit with an error code if the deploy command fails the "master branch" check
* Use simplified `apk add` functionality to avoid cache bloat