### PR TITLE
Use --set for everything except deploy.imageTag, where we use --set-string

### DIFF
--- a/commands/python/libs/k8s/helm.py
+++ b/commands/python/libs/k8s/helm.py
@@ -143,7 +143,7 @@ class Helm(object):
             command.append('--values={}'.format(path))
 
         for set_name, set_val in values.items():
-            command.extend(['--set-string', '{}={}'.format(set_name, set_val)])
+            command.extend(['--set', '{}={}'.format(set_name, set_val)])
 
         if helm_args:
             command.extend(helm_args)


### PR DESCRIPTION
- Upgrading helm to 2.11.0 changed how helm dealt with truthy/falsy values on --set-string. They used to handle it incorrectly, but now they handle it correctly. This PR addresses that switch. 