### PR TITLE
Remove pyyaml from requirements

### DIFF
--- a/commands/python/requirements.txt
+++ b/commands/python/requirements.txt
@@ -3,5 +3,4 @@ boto3==1.7.33
 cached-property==1.3.0
 colorlog==2.10.0
 jmespath==0.9.2
-pyyaml==3.12
 kubernetes==5.0.0


### PR DESCRIPTION
- It is not directly used
- awscli doesn't use the vulnerable pyyaml method as well: https://github.com/aws/aws-cli/issues/3828