### PR TITLE
[ALDN-126] Don't fail to enumerate pods when some are Failed

### DIFF
--- a/commands/python/command/connect.py
+++ b/commands/python/command/connect.py
@@ -29,7 +29,7 @@ def connect(app_name, namespace=None):
     idx = 0
     pod_container_pairs = []
     for pod in pods:
-        for container in pod.status.container_statuses:
+        for container in pod.status.container_statuses or []:
             print('{idx}: pod {pod_name}; container {container_name}'
                   .format(idx=idx, pod_name=pod.metadata.name, container_name=container.name))
             pod_container_pairs.append((pod.metadata.name, container.name))

--- a/commands/python/command/connect.py
+++ b/commands/python/command/connect.py
@@ -29,6 +29,7 @@ def connect(app_name, namespace=None):
     idx = 0
     pod_container_pairs = []
     for pod in pods:
+        # container_statuses may be None; don't fail in that case
         for container in pod.status.container_statuses or []:
             print('{idx}: pod {pod_name}; container {container_name}'
                   .format(idx=idx, pod_name=pod.metadata.name, container_name=container.name))


### PR DESCRIPTION
Under some circumstances (at least when a pod has been evicted), pod.status.container_statuses will be None and not enumerable.  We don't check for this, so if any pod is in such a state, running `aladdin connect` without arguments will fail and not allow specifying a deployment to connect to.  This PR catches that case.
    
[ALDN-126](https://fivestars.atlassian.net/browse/ALDN-126)