### PR TITLE
[ALDN-130] Allow running minikube with vm-driver=none

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN pip3 install --no-cache-dir -r ./commands/python/requirements.txt
 ARG KUBE_VERSION=1.15.6
 ARG KOPS_VERSION=1.15.0
 ARG HELM_VERSION=2.16.1
+ARG DOCKER_VERSION=18.09.7
 
 RUN	curl -L -o /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/amd64/kubectl \
 	&& chmod 755 /bin/kubectl
@@ -32,6 +33,9 @@ RUN	curl -L -o /bin/kops https://github.com/kubernetes/kops/releases/download/$K
 
 RUN	curl -L -o- https://storage.googleapis.com/kubernetes-helm/helm-v$HELM_VERSION-linux-amd64.tar.gz | tar -zxvf - && cp linux-amd64/helm \
 	/bin/helm && chmod 755 /bin/helm && helm init --client-only
+
+RUN curl -L -o- https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz | tar -zxvf - && cp docker/docker \
+    /usr/bin/docker && chmod 755 /usr/bin/docker
 
 RUN go get -u -v sigs.k8s.io/aws-iam-authenticator/cmd/aws-iam-authenticator
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ You will now need to [create your aladdin configuration](./docs/create_aladdin_c
 
     $ aladdin config set config_dir /path/to/aladdin/configuration
 
+### VM Configuration
+Currently, two parameters are configurable:
+1. memory: By default, we create a minikube vm with 4096MB (4GB) of memory.  To change the size of the vm we create to e.g. 8GB, you may run:
+```
+aladdin config set minikube.memory 8192
+```
+1. vm\_driver: By default, we use the 'virtualbox' virtualization backend.  Currently, we support only this and the `none` backend, which runs containers directly on the underlying OS without virtualization (only supported on
+   linux).  If your host is running linux, and you wish to use the 'none' backend (and avoid running in a VM), you may run,
+```
+aladdin config set minikube.vm_driver none
+```
+
+Note that these commands only take effect when the minikube cluster is first set up --- in order for them to take effect, you will need to first delete your existing minikube cluster (if present) and then (re-)run `aladdin --init`.
+
 ### NFS mounts
 
 Aladdin uses minikube for local development which is a VirtualBox-based VM. Internally it mounts your `/Users` (or `/cygdrive/c/Users` for Cygwin users) directory to the root of the minikube filesystem. We have discovered that the `vboxsf` mounts are not as performant as NFS mounts and furthermore are not as reliable when it comes to detecting file changes made from the host. To address this, we replace the `vboxsf` mounts within minikube with NFS mounts. However, this requires a bit of manual setup on the host machine before it will take effect.

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ You will now need to [create your aladdin configuration](./docs/create_aladdin_c
 
 ### VM Configuration
 Currently, two parameters are configurable:
-1. memory: By default, we create a minikube vm with 4096MB (4GB) of memory.  To change the size of the vm we create to e.g. 8GB, you may run:
+ * memory: By default, we create a minikube vm with 4096MB (4GB) of memory.  To change the size of the vm we create to e.g. 8GB, you may run:
 ```
 aladdin config set minikube.memory 8192
 ```
-1. vm\_driver: By default, we use the 'virtualbox' virtualization backend.  Currently, we support only this and the `none` backend, which runs containers directly on the underlying OS without virtualization (only supported on
+ * vm\_driver: By default, we use the 'virtualbox' virtualization backend.  Currently, we support only this and the `none` backend, which runs containers directly on the underlying OS without virtualization (only supported on
    linux).  If your host is running linux, and you wish to use the 'none' backend (and avoid running in a VM), you may run,
 ```
 aladdin config set minikube.vm_driver none

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Currently, two parameters are configurable:
 ```
 aladdin config set minikube.memory 8192
 ```
- * vm\_driver: By default, we use the 'virtualbox' virtualization backend.  Currently, we support only this and the `none` backend, which runs containers directly on the underlying OS without virtualization (only supported on
+ * vm\_driver: By default, we use the `virtualbox` virtualization backend.  Currently, we support only this and the `none` backend, which runs containers directly on the underlying OS without virtualization (only supported on
    linux).  If your host is running linux, and you wish to use the 'none' backend (and avoid running in a VM), you may run,
 ```
 aladdin config set minikube.vm_driver none

--- a/README.md
+++ b/README.md
@@ -54,16 +54,24 @@ You will now need to [create your aladdin configuration](./docs/create_aladdin_c
     $ aladdin config set config_dir /path/to/aladdin/configuration
 
 ### VM Configuration
-Currently, two parameters are configurable:
+Currently, the following parameters are configurable:
  * memory: By default, we create a minikube vm with 4096MB (4GB) of memory.  To change the size of the vm we create to e.g. 8GB, you may run:
-```
-aladdin config set minikube.memory 8192
-```
+   ```
+   aladdin config set minikube.memory 8192
+   ```
  * vm\_driver: By default, we use the `virtualbox` virtualization backend.  Currently, we support only this and the `none` backend, which runs containers directly on the underlying OS without virtualization (only supported on
    linux).  If your host is running linux, and you wish to use the 'none' backend (and avoid running in a VM), you may run,
-```
-aladdin config set minikube.vm_driver none
-```
+   ```
+   aladdin config set minikube.vm_driver none
+   ```
+ * disk\_size: The size of the VM disk, if applicable.  Defaults to the minikube default (20000M, as of this writing).
+   ```
+   aladdin config set minikube.disk_size 25000M
+   ```
+ * cpus: The number of vCPUs to provision the VM with, if applicable.  Defaults to the minikube default (2 as of this writing).
+   ```
+   aladdin config set minikube.cpus 4
+   ```
 
 Note that these commands only take effect when the minikube cluster is first set up --- in order for them to take effect, you will need to first delete your existing minikube cluster (if present) and then (re-)run `aladdin --init`.
 

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -128,7 +128,7 @@ function check_or_start_minikube() {
         echo "Starting minikube... (this will take a moment)"
         set_minikube_config
 
-        _start_minikube
+        _start_minikube >/dev/null
 
         # Determine if we've installed our bootlocal.sh script to replace the vboxsf mounts with nfs mounts
         if ! "$(minikube ssh -- "test -x /var/lib/boot2docker/bootlocal.sh && echo -n true || echo -n false")"; then

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -116,8 +116,10 @@ function check_or_start_minikube() {
         # Determine if we've installed our bootlocal.sh script to replace the vboxsf mounts with nfs mounts
         if ! "$(minikube ssh -- "test -x /var/lib/boot2docker/bootlocal.sh && echo -n true || echo -n false")"; then
             echo "Installing NFS mounts from host..."
-            "$SCRIPT_DIR"/install_nfs_mounts.sh
-            echo "NFS mounts NOT installed"
+            if test $(minikube config get vm-driver) != "none"; then
+                "$SCRIPT_DIR"/install_nfs_mounts.sh
+                echo "NFS mounts installed"
+            fi
         fi
         echo "Minikube started"
     else

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -128,7 +128,7 @@ function check_or_start_minikube() {
         echo "Starting minikube... (this will take a moment)"
         set_minikube_config
 
-        _start_minikube >/dev/null
+        _start_minikube &>/dev/null
 
         # Determine if we've installed our bootlocal.sh script to replace the vboxsf mounts with nfs mounts
         if ! "$(minikube ssh -- "test -x /var/lib/boot2docker/bootlocal.sh && echo -n true || echo -n false")"; then

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -116,7 +116,7 @@ function check_or_start_minikube() {
         # Determine if we've installed our bootlocal.sh script to replace the vboxsf mounts with nfs mounts
         if ! "$(minikube ssh -- "test -x /var/lib/boot2docker/bootlocal.sh && echo -n true || echo -n false")"; then
             echo "Installing NFS mounts from host..."
-            #"$SCRIPT_DIR"/install_nfs_mounts.sh
+            "$SCRIPT_DIR"/install_nfs_mounts.sh
             echo "NFS mounts NOT installed"
         fi
         echo "Minikube started"

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -98,7 +98,7 @@ function set_minikube_config(){
         local value=$(aladdin config get "minikube.$key" "${!default_var:-}")
 
         if test -n "$value"; then
-            minikube config set "$minikube_key" "$value"
+            minikube config set "$minikube_key" "$value" &> /dev/null
         fi
     done
 }

--- a/commands/bash/host/config/config
+++ b/commands/bash/host/config/config
@@ -12,19 +12,22 @@ function config() {
     fi
     case "$subcommand" in
         get)
-            result="$(jq -r ".$1" "$config_path")"
+            default="${2:-}"
+            result="$(jq -r --arg key "$1" 'getpath($key | split("."))' "$config_path")"
             if [[ ! "$result" == null ]]; then
                 echo $result
+            elif test -n "$default"; then
+                echo $default
             fi
         ;;
         set)
-            jq -c --arg key "$1" --arg val "$2" '. + { ($key): $val }' "$config_path" > "tmp.$$.json" && mv "tmp.$$.json" "$config_path"
+            jq --arg key "$1" --arg val "$2" 'setpath($key | split("."); $val)' "$config_path" > "tmp.$$.json" && mv "tmp.$$.json" "$config_path"
         ;;
         view)
             cat "$config_path"
         ;;
         unset)
-            jq -c "del(.$1)" "$config_path" > "tmp.$$.json" && mv "tmp.$$.json" "$config_path"
+            jq --arg key "$1" 'delpaths([$key | split(".")])' "$config_path" > "tmp.$$.json" && mv "tmp.$$.json" "$config_path"
         ;;
         *)
             echo "unknown subcommand $subcommand for aladdin config command"

--- a/scripts/infra_k8s_check.sh
+++ b/scripts/infra_k8s_check.sh
@@ -142,7 +142,7 @@ function check_ok(){ printf "${FG_GREEN}OK${RESET_COLOR}\n"; }
 function check_installing(){ printf "installing ... " ; }
 function check_done(){ printf "${FG_GREEN}done${RESET_COLOR}\n"; }
 function check_error(){ printf "${FG_RED_BOLD}FAILED%s${RESET_COLOR}\n" "${1:-}"; exit 1 ; }
-function check_warn() { printf "${FG_YELLOW_BOLD}Please install %s${RESET_COLOR}\n" "$1"; exit 1 ; }
+function check_warn() { printf "${FG_YELLOW_BOLD}Please install %s${RESET_COLOR}\n" "$1"; return 1 ; }
 
 ##################
 # Check functions (returning "true" or "false")
@@ -534,6 +534,7 @@ function install_jq_ubuntu(){ eval $install_cmd jq ; }
 function install_pip_ubuntu(){ eval $install_cmd python-pip ; }
 
 function check_pip(){ has_prog pip; }
+function check_socat(){ has_prog socat ; }
 
 function main(){
     if $NEED_INSTALL ; then
@@ -608,6 +609,8 @@ function main(){
               check_and_warn "python-pip         " pip
               check_and_warn "python3            " python3
               check_and_warn "aws-cli            " awscli
+
+              check_and_warn "socat (optional; needed if minikube.vm_driver = none)" socat || :
 
               # Only validate the script install at the end
               echo "$SCRIPT_HASH" > "$ALREADY_INSTALLED_FILE"


### PR DESCRIPTION
 This PR updates aladdin to allow running natively on the host's docker
 if available, by setting the new minikube.vm_driver preference in
 ~/.aladdin/config/config.json to 'none' (the default is 'virtualbox').
 This also adds a 'minikube.memory' preference to allow configuring
 the minikube VM's memory, if applicable.
 
 [ALDN-130](https://fivestars.atlassian.net/browse/ALDN-130)