### PR TITLE
[ALDN-147] Only check AWS credentials when performing cluster operations

### DIFF
--- a/aladdin-container.sh
+++ b/aladdin-container.sh
@@ -89,7 +89,9 @@ function environment_init() {
     export AWS_PROFILE="$AWS_DEFAULT_PROFILE"
 
     # Sanity check the user's aws configuration if init is set
-    $INIT && test_aws_config
+    if "$INIT" && ! "$IS_LOCAL"; then
+        test_aws_config
+    fi
 
     # Make sure we are on local or that cluster has been created before initializing helm, creating namespaces, etc
     if "$IS_LOCAL" || ( kops export kubecfg --name $CLUSTER_NAME &> /dev/null && \


### PR DESCRIPTION
We don't need to validate AWS credentials when working in minikube (ie. LOCAL development). One may not have even defined their `~/.aws/credentials` or `~/.aws/config` files yet, but still want to
try out some local behavior.

[ALDN-147](https://fivestars.atlassian.net/browse/ALDN-147)