### PR TITLE
Add assume role capabilities when bastion account is enabled

### DIFF
--- a/aladdin-container.sh
+++ b/aladdin-container.sh
@@ -17,7 +17,7 @@ export SCRIPT_DIR
 export ALADDIN_CONFIG_DIR
 export PY_MAIN
 
-source "$SCRIPT_DIR/shared.sh"
+source "$SCRIPT_DIR/shared.sh" # to load _extract_cluster_config_value
 
 # Test user's aws configuration
 function _test_aws_config() {
@@ -30,7 +30,7 @@ function _test_aws_config() {
         exit 1
     fi
     # Do a test aws cli call for the current aws profile
-    if ! aws s3 ls --profile "$profile" &>/dev/null; then
+    if ! aws iam list-users --profile "$profile" &>/dev/null; then
         echo "Your aws $profile credentials or config may be malformed; please check your ~/.aws/config and ~/.aws/credentials files"
         exit 1
     fi

--- a/aladdin-container.sh
+++ b/aladdin-container.sh
@@ -17,17 +17,21 @@ export SCRIPT_DIR
 export ALADDIN_CONFIG_DIR
 export PY_MAIN
 
+source "$SCRIPT_DIR/shared.sh"
+
 # Test user's aws configuration
-function test_aws_config() {
+function _test_aws_config() {
+    # Test aws configuration for a given profile: $1
     echo "Testing aws configuration..."
+    local profile=$1
     # See if we the current aws profile configured
-    if ! aws configure list --profile "$AWS_PROFILE" &>/dev/null; then
-        echo "Could not find aws profile: $AWS_PROFILE; please check your ~/.aws/config and ~/.aws/credentials files"
+    if ! aws configure list --profile "$profile" &>/dev/null; then
+        echo "Could not find aws profile: $profile; please check your ~/.aws/config and ~/.aws/credentials files"
         exit 1
     fi
     # Do a test aws cli call for the current aws profile
-    if ! aws s3 ls --profile "$AWS_PROFILE" &>/dev/null; then
-        echo "Your aws $AWS_PROFILE credentials or config may be malformed; please check your ~/.aws/config and ~/.aws/credentials files"
+    if ! aws s3 ls --profile "$profile" &>/dev/null; then
+        echo "Your aws $profile credentials or config may be malformed; please check your ~/.aws/config and ~/.aws/credentials files"
         exit 1
     fi
     echo "aws configuration check successful!"
@@ -85,13 +89,7 @@ function environment_init() {
     echo "CLUSTER_CODE = $CLUSTER_CODE"
     echo "NAMESPACE = $NAMESPACE"
 
-    # Kops uses AWS_PROFILE instead of AWS_DEFAULT_PROFILE
-    export AWS_PROFILE="$AWS_DEFAULT_PROFILE"
-
-    # Sanity check the user's aws configuration if init is set
-    if "$INIT" && ! "$IS_LOCAL"; then
-        test_aws_config
-    fi
+    _handle_aws_config
 
     # Make sure we are on local or that cluster has been created before initializing helm, creating namespaces, etc
     if "$IS_LOCAL" || ( kops export kubecfg --name $CLUSTER_NAME &> /dev/null && \
@@ -108,7 +106,7 @@ function environment_init() {
         kubectl config set-context "$NAMESPACE.$CLUSTER_NAME" --cluster "$CLUSTER_NAME" --namespace="$NAMESPACE" --user "$CLUSTER_NAME"
         kubectl config use-context "$NAMESPACE.$CLUSTER_NAME"
 
-        add_and_set_authentication_users
+        _handle_authentication_config
 
         if $INIT; then
             kubectl create namespace --cluster $CLUSTER_NAME $NAMESPACE || true
@@ -123,7 +121,8 @@ function environment_init() {
 }
 
 function _initialize_helm() {
-    if $RBAC_ENABLED; then
+    local rbac_enabled="$(_extract_cluster_config_value rbac_enabled)"
+    if $rbac_enabled; then
         kubectl -n kube-system create serviceaccount tiller || true
         kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller || true
         helm init --service-account=tiller --upgrade --wait || true
@@ -132,9 +131,17 @@ function _initialize_helm() {
     fi
 }
 
-function add_and_set_authentication_users() {
-    # If authentication is enabled, add the appropriate users to our kubeconfig
+function _handle_authentication_config() {
+    # This function adds appropriate users to kubeconfig, and exports necessary AUTHENTICATION variables
+    # export AUTHENTICATION_ENABLED for change-permissions and bash command
+    export AUTHENTICATION_ENABLED="$(_extract_cluster_config_value authentication_enabled)"
     if $AUTHENTICATION_ENABLED; then
+        AUTHENTICATION_ROLES="$(_extract_cluster_config_value authentication_roles)"
+        AUTHENTICATION_ALADDIN_ROLE="$(_extract_cluster_config_value authentication_aladdin_role)"
+        # export AUTHENTICATION_DEFAULT_ROLE for bash command
+        export AUTHENTICATION_DEFAULT_ROLE="$(_extract_cluster_config_value authentication_default_role)"
+        # export AUTHENTICATION_ALLOWED_CHANGE_ROLES for change-permissions command
+        export AUTHENTICATION_ALLOWED_CHANGE_ROLES="$(_extract_cluster_config_value authentication_allowed_change_roles)"
         jq -r '.|keys[]' <<< "$AUTHENTICATION_ROLES" | while read name ; do
             role_arn="$(jq -r --arg name "$name" '.[$name]' <<< $AUTHENTICATION_ROLES)"
             _add_authentication_user_to_kubeconfig "$name" "$role_arn"
@@ -159,6 +166,61 @@ function _add_authentication_user_to_kubeconfig() {
       - $role_arn
       command: aws-iam-authenticator
 EOT
+}
+
+function _handle_aws_config() {
+    # This function does quite a few things with aws credentials/config files:
+    # 1) Move the mounted aws creds to ~/.aws
+    # 2) Checks if we have the BASTION_ACCOUNT_ENABLED configuration from our aladdin-config
+    # 3) If we do:
+    #        - export appropriate BASTION_ variables for other aladdin commands
+    #        - sanity test our aws configuration for the bastion account if INIT and not IS_LOCAL
+    #        - appropriately update our credentials/config files with the desired possible roles
+    #            - here we are calling the add-aws-assume-role-config aladdin command
+    # 4) If we do not:
+    #        - sanity test our aws configuration for the cluster's current aws account if INIT and not IS_LOCAL
+    # 5) Export AWS_PROFILE=$AWS_DEFAULT_PROFILE because kops uses the former
+
+    # Move aws credentials away from mount so we don't edit the host's aws files
+    cp -r /root/tmp/.aws /root/.aws
+    # See if bastion account is enabled
+    export BASTION_ACCOUNT_ENABLED="$(_extract_cluster_config_value bastion_account_enabled)"
+    if "$BASTION_ACCOUNT_ENABLED"; then
+        # Export BASTION_ACCOUNT_PROFILE, needed by add-aws-assume-role-config command
+        export BASTION_ACCOUNT_PROFILE="$(_extract_cluster_config_value bastion_account_profile)"
+        # Need to unset AWS_DEFAULT_PROFILE because aws requires that entry to exist even if we
+        # are specifying --profile to a separate present entry, which is expected in the bastion case
+        local aws_default_profile_temp="$AWS_DEFAULT_PROFILE"
+        unset AWS_DEFAULT_PROFILE
+        # Test aws config for bastion account if INIT and not IS_LOCAL
+        if "$INIT" && ! "$IS_LOCAL"; then
+            _test_aws_config "$BASTION_ACCOUNT_PROFILE"
+        fi
+        # Alias the add assume role config command
+        add_assume_role_config="$ALADDIN_DIR/commands/bash/container/add-aws-assume-role-config/add-aws-assume-role-config"
+        # Need to add aws configuration based on publish configuration.
+        # We need to do this because the publish ECR may be a different aws account than the one
+        # your cluster is provisioned in
+        publish_config="$(_extract_cluster_config_value publish)"
+        publish_profile="$(jq -r '.aws_profile' <<< $publish_config)"
+        publish_role="$(jq -r '.aws_role_to_assume' <<< $publish_config)"
+        publish_mfa_enabled="$(jq -r '.aws_role_mfa_required' <<< $publish_config)"
+        "$add_assume_role_config" "$publish_role" "$publish_profile" "$publish_mfa_enabled" 3600 # 1 hour
+        # Need to add aws configuration for current cluster's aws account
+        aws_profile="$(_extract_cluster_config_value bastion_account_profile_to_assume)"
+        aws_role="$(_extract_cluster_config_value bastion_account_role_to_assume)"
+        aws_mfa_enabled="$(_extract_cluster_config_value bastion_account_mfa_enabled)"
+        "$add_assume_role_config" "$aws_role" "$aws_profile" "$aws_mfa_enabled" 3600 # 1 hour
+        # We reset AWS_DEFAULT_PROFILE here because that entry will be present in aws config files now
+        export AWS_DEFAULT_PROFILE="$aws_default_profile_temp"
+    else
+        # Test aws config for current cluster's aws account if INIT and not IS_LOCAL
+        if "$INIT" && ! "$IS_LOCAL"; then
+            _test_aws_config "$AWS_DEFAULT_PROFILE"
+        fi
+    fi
+    # Kops uses AWS_PROFILE instead of AWS_DEFAULT_PROFILE
+    export AWS_PROFILE="$AWS_DEFAULT_PROFILE"
 }
 
 source_cluster_env

--- a/aladdin-container.sh
+++ b/aladdin-container.sh
@@ -25,12 +25,12 @@ function _test_aws_config() {
     echo "Testing aws configuration..."
     local profile=$1
     # See if we the current aws profile configured
-    if ! aws configure list --profile "$profile" &>/dev/null; then
+    if ! aws configure list --profile "$profile" >/dev/null; then
         echo "Could not find aws profile: $profile; please check your ~/.aws/config and ~/.aws/credentials files"
         exit 1
     fi
     # Do a test aws cli call for the current aws profile
-    if ! aws iam list-users --profile "$profile" &>/dev/null; then
+    if ! aws iam list-users --profile "$profile" >/dev/null; then
         echo "Your aws $profile credentials or config may be malformed; please check your ~/.aws/config and ~/.aws/credentials files"
         exit 1
     fi

--- a/aladdin-container.sh
+++ b/aladdin-container.sh
@@ -30,7 +30,7 @@ function _test_aws_config() {
         exit 1
     fi
     # Do a test aws cli call for the current aws profile
-    if ! aws iam list-users --profile "$profile" >/dev/null; then
+    if ! aws sts get-caller-identity --profile "$profile" >/dev/null; then
         echo "Your aws $profile credentials or config may be malformed; please check your ~/.aws/config and ~/.aws/credentials files"
         exit 1
     fi

--- a/aladdin-container.sh
+++ b/aladdin-container.sh
@@ -92,8 +92,8 @@ function environment_init() {
     _handle_aws_config
 
     # Make sure we are on local or that cluster has been created before initializing helm, creating namespaces, etc
-    if "$IS_LOCAL" || ( kops export kubecfg --name $CLUSTER_NAME &> /dev/null && \
-        kops validate cluster --name $CLUSTER_NAME ) &> /dev/null; then
+    if "$IS_LOCAL" || ( kops export kubecfg --name $CLUSTER_NAME > /dev/null && \
+        kops validate cluster --name $CLUSTER_NAME ) > /dev/null; then
 
         if "$IS_LOCAL"; then
             mkdir -p $HOME/.kube/

--- a/aladdin-container.sh
+++ b/aladdin-container.sh
@@ -192,10 +192,8 @@ function _handle_aws_config() {
         # are specifying --profile to a separate present entry, which is expected in the bastion case
         local aws_default_profile_temp="$AWS_DEFAULT_PROFILE"
         unset AWS_DEFAULT_PROFILE
-        # Test aws config for bastion account if INIT and not IS_LOCAL
-        if "$INIT" && ! "$IS_LOCAL"; then
-            _test_aws_config "$BASTION_ACCOUNT_PROFILE"
-        fi
+        # Test aws config for bastion account
+        "$INIT" && _test_aws_config "$BASTION_ACCOUNT_PROFILE"
         # Alias the add assume role config command
         add_assume_role_config="$ALADDIN_DIR/commands/bash/container/add-aws-assume-role-config/add-aws-assume-role-config"
         # Need to add aws configuration based on publish configuration.

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -28,6 +28,8 @@ PATH="$ALADDIN_BIN":"$PATH"
 DEFAULT_MINIKUBE_VM_DRIVER="virtualbox"
 DEFAULT_MINIKUBE_MEMORY=4096
 
+source "$SCRIPT_DIR/shared.sh"
+
 function get_config_path() {
     if [[ ! -f "$HOME/.aladdin/config/config.json" ]]; then
         echo "Unable to find config directory. Please use 'aladdin config set config_dir <config path location>' to set config directory"
@@ -180,15 +182,6 @@ function enter_minikube_env() {
     fi
 }
 
-function _extract_cluster_config_value() {
-    # Try extracting config from cluster config.json, default config.json, then aladdin config.json
-    local value
-    value="$1"
-    jq -nr --arg value "$value" 'first(inputs | (if .[$value] == null then empty else .[$value] end))' \
-        "$ALADDIN_CONFIG_DIR/$CLUSTER_CODE/config.json" "$ALADDIN_CONFIG_DIR/default/config.json" \
-        "$ALADDIN_CONFIG_DIR/config.json"
-}
-
 function set_cluster_helper_vars() {
     IS_LOCAL="$(_extract_cluster_config_value is_local)"
     if [[ -z "$IS_LOCAL" ]]; then
@@ -203,21 +196,6 @@ function set_cluster_helper_vars() {
     IS_TESTING="$(_extract_cluster_config_value is_testing)"
     if [[ -z "$IS_TESTING" ]]; then
         IS_TESTING=false
-    fi
-
-    RBAC_ENABLED="$(_extract_cluster_config_value rbac_enabled)"
-    if [[ -z "$RBAC_ENABLED" ]]; then
-        RBAC_ENABLED=false
-    fi
-
-    AUTHENTICATION_ENABLED="$(_extract_cluster_config_value authentication_enabled)"
-    if [[ -z "$AUTHENTICATION_ENABLED" ]]; then
-        AUTHENTICATION_ENABLED=false
-    else
-        AUTHENTICATION_ROLES="$(_extract_cluster_config_value authentication_roles)"
-        AUTHENTICATION_ALADDIN_ROLE="$(_extract_cluster_config_value authentication_aladdin_role)"
-        AUTHENTICATION_DEFAULT_ROLE="$(_extract_cluster_config_value authentication_default_role)"
-        AUTHENTICATION_ALLOWED_CHANGE_ROLES="$(_extract_cluster_config_value authentication_allowed_change_roles)"
     fi
 }
 
@@ -336,15 +314,11 @@ function enter_docker_container() {
         -e "IS_PROD=$IS_PROD" \
         -e "IS_TESTING=$IS_TESTING" \
         -e "SKIP_PROMPTS=$SKIP_PROMPTS" \
-        -e "RBAC_ENABLED=$RBAC_ENABLED" \
-        -e "AUTHENTICATION_ENABLED=$AUTHENTICATION_ENABLED" \
-        -e "AUTHENTICATION_ROLES=$AUTHENTICATION_ROLES" \
-        -e "AUTHENTICATION_DEFAULT_ROLE=$AUTHENTICATION_DEFAULT_ROLE" \
-        -e "AUTHENTICATION_ALADDIN_ROLE=$AUTHENTICATION_ALADDIN_ROLE" \
-        -e "AUTHENTICATION_ALLOWED_CHANGE_ROLES=$AUTHENTICATION_ALLOWED_CHANGE_ROLES" \
         -e "command=$command" \
         `# Mount host credentials` \
-        -v "$(pathnorm ~/.aws):/root/.aws" \
+        `# Mount destination for aws creds will not be /root/.aws because we will possibly make` \
+        `# changes there that we don't want propagated on the host's ~/.aws` \
+        -v "$(pathnorm ~/.aws):/root/tmp/.aws" \
         -v "${ssh_src}:/root/.ssh" \
         -v "$(pathnorm ~/.kube):/root/.kube_local" \
         -v "$(pathnorm ~/.aladdin):/root/.aladdin" \

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -76,7 +76,7 @@ function check_and_handle_init() {
     if "$INIT"; then
         "$SCRIPT_DIR"/infra_k8s_check.sh --force
         enter_minikube_env
-        minikube addons enable ingress &> /dev/null
+        minikube addons enable ingress > /dev/null
         readonly repo_login_command="$(jq -r '.aladdin.repo_login_command' "$ALADDIN_CONFIG_FILE")"
         if [[ "$repo_login_command" != "null" ]]; then
             eval "$repo_login_command"
@@ -91,7 +91,7 @@ function check_and_handle_init() {
 }
 
 function set_minikube_config(){
-    minikube config set kubernetes-version v$KUBERNETES_VERSION &> /dev/null
+    minikube config set kubernetes-version v$KUBERNETES_VERSION > /dev/null
 
     for key in vm_driver memory disk_size cpus; do
         local minikube_key=$(tr _ - <<< "$key")  # e.g., vm-driver
@@ -100,7 +100,7 @@ function set_minikube_config(){
         local value=$(aladdin config get "minikube.$key" "${!default_var:-}")
 
         if test -n "$value"; then
-            minikube config set "$minikube_key" "$value" &> /dev/null
+            minikube config set "$minikube_key" "$value" > /dev/null
         fi
     done
 }
@@ -131,7 +131,7 @@ function _start_minikube() {
 
 # Start minikube if we need to
 function check_or_start_minikube() {
-    if ! minikube status | grep Running &> /dev/null; then
+    if ! minikube status | grep Running > /dev/null; then
 
         echo "Starting minikube... (this will take a moment)"
         set_minikube_config
@@ -148,10 +148,10 @@ function check_or_start_minikube() {
         fi
         echo "Minikube started"
     else
-        if ! kubectl version | grep "Server" | grep "$KUBERNETES_VERSION" &> /dev/null; then
+        if ! kubectl version | grep "Server" | grep "$KUBERNETES_VERSION" > /dev/null; then
             echo "Minikube detected on the incorrect version, stopping and restarting"
-            minikube stop &> /dev/null
-            minikube delete &> /dev/null
+            minikube stop > /dev/null
+            minikube delete > /dev/null
             set_minikube_config
             check_or_start_minikube
         fi

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -28,7 +28,7 @@ PATH="$ALADDIN_BIN":"$PATH"
 DEFAULT_MINIKUBE_VM_DRIVER="virtualbox"
 DEFAULT_MINIKUBE_MEMORY=4096
 
-source "$SCRIPT_DIR/shared.sh"
+source "$SCRIPT_DIR/shared.sh" # to load _extract_cluster_config_value
 
 function get_config_path() {
     if [[ ! -f "$HOME/.aladdin/config/config.json" ]]; then

--- a/commands/bash/container/add-aws-assume-role-config/add-aws-assume-role-config
+++ b/commands/bash/container/add-aws-assume-role-config/add-aws-assume-role-config
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+function add_aws_assume_role_config {
+    # This command edits your aws config and credentials file to add aws_access_key_id,
+    # aws_access_key_secret, aws_session_token, and region for role $1, under profile $2. We will
+    # prompt the user for an MFA token if $3 is true, and the temporary credentials will last for
+    # $4 seconds.
+
+    if ! "$BASTION_ACCOUNT_ENABLED"; then
+        echo >&2 "aladdin: error: bastion account is not enabled currently. update your aladdin-config to enable"
+        exit 1
+    fi
+
+    local role="$1"
+    local profile_name="$2"
+    local mfa_enabled="$3"
+    local duration="$4"
+
+    session_name="$(aws --profile $BASTION_ACCOUNT_PROFILE sts get-caller-identity \
+        --query 'Arn' --output text | cut -d '/' -f2)"
+
+    if "$mfa_enabled"; then
+
+        mfa_serial="$(aws --profile operations iam list-mfa-devices \
+            --query 'MFADevices[0].SerialNumber' --output text)"
+
+        # Ask the user for their MFA token in yellow color
+        echo -ne '\e[33mPlease enter your AWS MFA token: \e[0m'; read -r token
+
+        payload="$(aws --profile $BASTION_ACCOUNT_PROFILE sts assume-role  \
+            --role-arn $role --duration-seconds $duration --serial-number $mfa_serial \
+            --token $token --role-session-name $session_name)"
+    else
+
+        payload="$(aws --profile $BASTION_ACCOUNT_PROFILE sts assume-role  \
+            --role-arn $role --duration-seconds "$duration" --role-session-name "$session_name")"
+    fi
+
+    aws configure --profile "$profile_name" set aws_access_key_id "$(jq -r .Credentials.AccessKeyId <<< $payload)"
+    aws configure --profile "$profile_name" set aws_secret_access_key "$(jq -r .Credentials.SecretAccessKey <<< $payload)"
+    aws configure --profile "$profile_name" set aws_session_token "$(jq -r .Credentials.SessionToken <<< $payload)"
+    aws configure --profile "$profile_name" set region "$AWS_DEFAULT_REGION"
+}
+
+
+function usage {
+    cat <<-EOF
+		usage: aladdin aws-assume-role [-h] permission
+
+		positional arguments:
+		  role                  which role to set aws config for
+		  profile_name          the name of the aws profile
+		  mfa_enabled           whether to prompt user for MFA token
+		  duration              how long these credentials will last in seconds before expiring
+
+		optional arguments:
+		  -h, --help            show this help message and exit
+		  -d, --duration        how long the assume role configuration should be valid for in seconds, defaults to 3600
+	EOF
+}
+
+if [[ $# -eq 0 || "$1" == "-h" || "$1" == "--help" ]]; then
+    usage
+else
+    add_aws_assume_role_config "$@"
+fi

--- a/commands/bash/container/add-aws-assume-role-config/add-aws-assume-role-config
+++ b/commands/bash/container/add-aws-assume-role-config/add-aws-assume-role-config
@@ -46,7 +46,7 @@ function add_aws_assume_role_config {
 
 function usage {
     cat <<-EOF
-		usage: aladdin aws-assume-role [-h] permission
+		usage: aladdin aws-assume-role [-h] role profile_name mfa_enabled duration
 
 		positional arguments:
 		  role                  which role to set aws config for
@@ -56,7 +56,6 @@ function usage {
 
 		optional arguments:
 		  -h, --help            show this help message and exit
-		  -d, --duration        how long the assume role configuration should be valid for in seconds, defaults to 3600
 	EOF
 }
 

--- a/commands/python/bash_help.json
+++ b/commands/python/bash_help.json
@@ -1,4 +1,7 @@
 {
+    "add-aws-assume-role-config": {
+        "help": "Update your aws configuration to have credentials for an assumed role under a given profile"
+    },
     "bash": {
         "help": "Launch bash in the context of aladdin"
     },

--- a/scripts/bash_profile.bash
+++ b/scripts/bash_profile.bash
@@ -9,7 +9,7 @@ echo "Don't forget to checkout scripts/bash_profile.bash in aladdin"
 function change_to_aladdin_permission() {
     echo "Temporarily changing your permissions to run aladdin command..."
     kubectl config set-context "$NAMESPACE.$CLUSTER_NAME" --cluster "$CLUSTER_NAME" \
-        --namespace="$NAMESPACE" --user "$AUTHENTICATION_ALADDIN_ROLE" &> /dev/null
+        --namespace="$NAMESPACE" --user "$AUTHENTICATION_ALADDIN_ROLE" > /dev/null
 }
 
 function get_current_user() {
@@ -21,7 +21,7 @@ function restore_permission() {
     old_user="$1"
     echo "Reverting your permissions back to $old_user"
     kubectl config set-context "$NAMESPACE.$CLUSTER_NAME" --cluster "$CLUSTER_NAME" \
-        --namespace="$NAMESPACE" --user "$old_user" &> /dev/null
+        --namespace="$NAMESPACE" --user "$old_user" > /dev/null
 }
 
 function with_aladdin_perms_wrapper() {

--- a/scripts/shared.sh
+++ b/scripts/shared.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# This file is for functions that can be shared between aladdin.sh and aladdin-container.sh
+
+set -a
+set -eu -o pipefail
+
+function _extract_cluster_config_value() {
+    # Try extracting config from cluster config.json, default config.json, then aladdin config.json
+    local value
+    value="$1"
+    jq -nr --arg value "$value" 'first(inputs | (if .[$value] == null then empty else .[$value] end))' \
+        "$ALADDIN_CONFIG_DIR/$CLUSTER_CODE/config.json" "$ALADDIN_CONFIG_DIR/default/config.json" \
+        "$ALADDIN_CONFIG_DIR/config.json"
+}


### PR DESCRIPTION
High level:
- There will require an accompanying aladdin-config PR, that specifies which bastion account to use, and different roles we can assume (role that has sufficient privileges to run all aladdin command).
- Then, during aladdin's startup, we will now configure the ~/.aws/config and ~/.aws/credentials files to have the temporary credentials that are issued when calling `aws sts assume-role` for a given profile. 
- Users will now only be required to have aws config/creds file for the bastion account