### PR TITLE
[ALDN-157] Fix regex for copying kube config into aladdin container

### DIFF
--- a/aladdin-container.sh
+++ b/aladdin-container.sh
@@ -98,6 +98,8 @@ function environment_init() {
         if "$IS_LOCAL"; then
             mkdir -p $HOME/.kube/
             cp $HOME/.kube_local/config $HOME/.kube/config
+            # Replace e.g. /Users/ptr/.minikube with /root/.minikube in the minikube conf dir path
+            # (since that's where it will be mounted within the aladdin container)
             sed 's#: ?.*\.minikube#: /root/.minikube#' $HOME/.kube_local/config > $HOME/.kube/config
         else
             cp $HOME/.kube/config $HOME/.kube_local/$CLUSTER_NAME.config

--- a/aladdin-container.sh
+++ b/aladdin-container.sh
@@ -98,7 +98,7 @@ function environment_init() {
         if "$IS_LOCAL"; then
             mkdir -p $HOME/.kube/
             cp $HOME/.kube_local/config $HOME/.kube/config
-            sed 's/: .*[\\\/]\([a-z]*\.[a-z]*\)$/: \/root\/.minikube\/\1/g' $HOME/.kube_local/config > $HOME/.kube/config
+            sed 's#: ?.*\.minikube#: /root/.minikube#' $HOME/.kube_local/config > $HOME/.kube/config
         else
             cp $HOME/.kube/config $HOME/.kube_local/$CLUSTER_NAME.config
         fi


### PR DESCRIPTION
The regex we use to replace e.g. /Users/ptr/.minikube with /root/.minikube
was overly greedy, swallowing up path components that it shouldn't.  It
wasn't a problem while client.key and client.crt were in the top level of
.minikube/, but more recent minikube puts them in
.minikube/profiles/minikube, where aladdin now can't find them.

This commit updates the regex to just replace the path components up
to .minikube/ .