### PR TITLE
Pass extra args through to build command

### DIFF
--- a/commands/python/command/build.py
+++ b/commands/python/command/build.py
@@ -3,15 +3,17 @@ from project.project_conf import ProjectConf
 
 
 def parse_args(sub_parser):
-    subparser = sub_parser.add_parser('build',
-                                      help='Build a project\'s docker images for local development')
+    subparser = sub_parser.add_parser(
+        "build", help="Build a project's docker images for local development"
+    )
+    subparser.add_argument("build_args", nargs="*")
     subparser.set_defaults(func=build_args)
 
 
 def build_args(args):
-    build()
+    build(args.build_args)
 
 
-def build():
+def build(build_args):
     pc = ProjectConf()
-    pc.build_docker(env={'HASH':'local'})
+    pc.build_docker(env={"HASH": "local"}, build_args=build_args)

--- a/commands/python/command/build.py
+++ b/commands/python/command/build.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import argparse
+
 from project.project_conf import ProjectConf
 
 
@@ -6,7 +8,7 @@ def parse_args(sub_parser):
     subparser = sub_parser.add_parser(
         "build", help="Build a project's docker images for local development"
     )
-    subparser.add_argument("build_args", nargs="*")
+    subparser.add_argument("build_args", nargs=argparse.REMAINDER)
     subparser.set_defaults(func=build_args)
 
 

--- a/commands/python/project/project_conf.py
+++ b/commands/python/project/project_conf.py
@@ -63,13 +63,14 @@ class ProjectConf(object):
     @property
     def build_command(self):
         cmd = search('build_docker', self.lamp_content)
-        if isinstance(cmd, str):
-            return [cmd]
-        return cmd
+        return [cmd] if isinstance(cmd, str) else cmd
 
-    def build_docker(self, env=None):
+    def build_docker(self, env=None, build_args=None):
         env = env or {}
-        command = self.build_command
+        build_args = build_args or []
+
+        command = self.build_command[:]
+        command.extend(build_args)
 
         run_env = os.environ.copy()
         run_env.update(env)


### PR DESCRIPTION
This change lets one provide extra arguments to the build script specified
in the `lamp.json` file. This can be useful during development if your build
takes a relatively long time and you want to only perform a partial build.