### PR TITLE
Add support for commands-base:2.0.0

### DIFF
--- a/commands/python/command/cmd.py
+++ b/commands/python/command/cmd.py
@@ -3,17 +3,27 @@ import logging
 import subprocess
 import sys
 
+from jmespath import search
+
 from arg_tools import add_namespace_argument
 from libs.k8s.kubernetes import Kubernetes
+from project.project_conf import ProjectConf
 
 
 def parse_args(sub_parser):
-    subparser = sub_parser.add_parser('cmd',
-                                      help='Run commands on specifc project via its commands pod')
-    subparser.add_argument('app_name', type=str, metavar='app_name',
-                           help='app to run commands against')
-    subparser.add_argument('command_args', type=str, metavar='comm_args',
-                           help='command and its args', nargs=argparse.REMAINDER)
+    subparser = sub_parser.add_parser(
+        "cmd", help="Run commands on specifc project via its commands pod"
+    )
+    subparser.add_argument(
+        "app_name", type=str, metavar="app_name", help="app to run commands against"
+    )
+    subparser.add_argument(
+        "command_args",
+        type=str,
+        metavar="comm_args",
+        help="command and its args",
+        nargs=argparse.REMAINDER,
+    )
     add_namespace_argument(subparser)
     subparser.set_defaults(func=cmd_args)
 
@@ -26,11 +36,34 @@ def cmd(app_name, command_args, namespace=None):
     k = Kubernetes(namespace=namespace)
     pod_name = k.get_pod_name("%s-commands" % app_name)
     logging.info("Command output below...")
-    try:
-        # See if the commands container uses python3
-        executable = k.kub_exec(pod_name, "%s-commands" % app_name, 'which', 'python3',
-                                return_output=True).decode(sys.stdout.encoding).strip()
-    except subprocess.CalledProcessError:
-        # If not, we assume it uses python
-        executable = 'python'
-    k.kub_exec(pod_name, "%s-commands" % app_name, executable, 'command.py', *command_args)
+
+    pc = ProjectConf()
+    cmd_config = search("cmd", pc.commands_config)
+
+    if search("version", cmd_config) == 2:
+        # In commands-base 2.0.0, we moved the commands.py script to /usr/local/bin/aladdin_cmd
+        # and made it executable. It's expected that the implementer will provide a she-bang line to
+        # indicate which interpreter to use (or none at all if they are using a compiled executable)
+        k.kub_exec(pod_name, "%s-commands" % app_name, "/usr/local/bin/aladdin_cmd", *command_args)
+    else:
+
+        logging.warning(
+            "commands-base:1.0.0 is deprecated."
+            " Update your commands images to commands-base:2.0.0"
+            " and set commands.cmd.version=2 in your lamp.json file."
+        )
+
+        try:
+            # See if the commands container uses python3
+            executable = (
+                k.kub_exec(
+                    pod_name, "%s-commands" % app_name, "which", "python3", return_output=True
+                )
+                .decode(sys.stdout.encoding)
+                .strip()
+            )
+        except subprocess.CalledProcessError:
+            # If not, we assume it uses python
+            executable = "python"
+
+        k.kub_exec(pod_name, "%s-commands" % app_name, executable, "command.py", *command_args)

--- a/commands/python/command/cmd.py
+++ b/commands/python/command/cmd.py
@@ -35,7 +35,7 @@ def cmd(app_name, command_args, namespace=None):
     logging.info("Command output below...")
 
     try:
-        # In commands-base:2.0.0, we moved the commands.py script to /usr/local/bin/aladdin_cmd
+        # In commands-base:2.0.0, we moved the commands.py script to /usr/local/bin/aladdin_cmd_v2
         # and made it executable. It's expected that the implementer will provide a she-bang line to
         # indicate which interpreter to use (or none at all if they are using a compiled executable)
         k.kub_exec(
@@ -43,7 +43,7 @@ def cmd(app_name, command_args, namespace=None):
             f"{app_name}-commands",
             "/bin/bash",
             "-c",
-            "test -x /usr/local/bin/aladdin_cmd",
+            "test -x /usr/local/bin/aladdin_cmd_v2",
         )
     except subprocess.CalledProcessError:
         # commands-base:1.0.0 behavior
@@ -65,4 +65,4 @@ def cmd(app_name, command_args, namespace=None):
         k.kub_exec(pod_name, f"{app_name}-commands", executable, "command.py", *command_args)
     else:
         # commands-base:2.0.0 behavior
-        k.kub_exec(pod_name, f"{app_name}-commands", "/usr/local/bin/aladdin_cmd", *command_args)
+        k.kub_exec(pod_name, f"{app_name}-commands", "/usr/local/bin/aladdin_cmd_v2", *command_args)

--- a/commands/python/command/cmd.py
+++ b/commands/python/command/cmd.py
@@ -31,7 +31,7 @@ def cmd_args(args):
 
 def cmd(app_name, command_args, namespace=None):
     k = Kubernetes(namespace=namespace)
-    pod_name = k.get_pod_name("%s-commands" % app_name)
+    pod_name = k.get_pod_name(f"{app_name}-commands")
     logging.info("Command output below...")
 
     try:
@@ -40,7 +40,7 @@ def cmd(app_name, command_args, namespace=None):
         # indicate which interpreter to use (or none at all if they are using a compiled executable)
         k.kub_exec(
             pod_name,
-            "%s-commands" % app_name,
+            f"{app_name}-commands",
             "/bin/bash",
             "-c",
             "test -x /usr/local/bin/aladdin_cmd",
@@ -54,9 +54,7 @@ def cmd(app_name, command_args, namespace=None):
         try:
             # See if the commands container uses python3
             executable = (
-                k.kub_exec(
-                    pod_name, "%s-commands" % app_name, "which", "python3", return_output=True
-                )
+                k.kub_exec(pod_name, f"{app_name}-commands", "which", "python3", return_output=True)
                 .decode(sys.stdout.encoding)
                 .strip()
             )
@@ -64,7 +62,7 @@ def cmd(app_name, command_args, namespace=None):
             # If not, we assume it uses python
             executable = "python"
 
-        k.kub_exec(pod_name, "%s-commands" % app_name, executable, "command.py", *command_args)
+        k.kub_exec(pod_name, f"{app_name}-commands", executable, "command.py", *command_args)
     else:
         # commands-base:2.0.0 behavior
-        k.kub_exec(pod_name, "%s-commands" % app_name, "/usr/local/bin/aladdin_cmd", *command_args)
+        k.kub_exec(pod_name, f"{app_name}-commands", "/usr/local/bin/aladdin_cmd", *command_args)

--- a/commands/python/command/cmd.py
+++ b/commands/python/command/cmd.py
@@ -3,11 +3,8 @@ import logging
 import subprocess
 import sys
 
-from jmespath import search
-
 from arg_tools import add_namespace_argument
 from libs.k8s.kubernetes import Kubernetes
-from project.project_conf import ProjectConf
 
 
 def parse_args(sub_parser):
@@ -37,20 +34,21 @@ def cmd(app_name, command_args, namespace=None):
     pod_name = k.get_pod_name("%s-commands" % app_name)
     logging.info("Command output below...")
 
-    pc = ProjectConf()
-    cmd_config = search("cmd", pc.commands_config)
-
-    if search("version", cmd_config) == 2:
-        # In commands-base 2.0.0, we moved the commands.py script to /usr/local/bin/aladdin_cmd
+    try:
+        # In commands-base:2.0.0, we moved the commands.py script to /usr/local/bin/aladdin_cmd
         # and made it executable. It's expected that the implementer will provide a she-bang line to
         # indicate which interpreter to use (or none at all if they are using a compiled executable)
-        k.kub_exec(pod_name, "%s-commands" % app_name, "/usr/local/bin/aladdin_cmd", *command_args)
-    else:
-
+        k.kub_exec(
+            pod_name,
+            "%s-commands" % app_name,
+            "/bin/bash",
+            "-c",
+            "test -x /usr/local/bin/aladdin_cmd",
+        )
+    except subprocess.CalledProcessError:
+        # commands-base:1.0.0 behavior
         logging.warning(
-            "commands-base:1.0.0 is deprecated."
-            " Update your commands images to commands-base:2.0.0"
-            " and set commands.cmd.version=2 in your lamp.json file."
+            "commands-base:1.0.0 is deprecated. Update your commands images to commands-base:2.0.0."
         )
 
         try:
@@ -67,3 +65,6 @@ def cmd(app_name, command_args, namespace=None):
             executable = "python"
 
         k.kub_exec(pod_name, "%s-commands" % app_name, executable, "command.py", *command_args)
+    else:
+        # commands-base:2.0.0 behavior
+        k.kub_exec(pod_name, "%s-commands" % app_name, "/usr/local/bin/aladdin_cmd", *command_args)

--- a/commands/python/libs/k8s/kubernetes.py
+++ b/commands/python/libs/k8s/kubernetes.py
@@ -65,8 +65,8 @@ class Kubernetes(object):
             cmd_list = self._kub_cmd('exec', flags, pod_name, '--', *command)
 
         if return_output:
-            DEVNULL = open(os.devnull, 'w')
-            return subprocess.check_output(cmd_list, stderr=DEVNULL)
+            with open(os.devnull, "w") as devnull:
+                return subprocess.check_output(cmd_list, stderr=devnull)
         subprocess.check_call(cmd_list)
 
     def tail_logs(self, deployment_name=None, pod_name=None, container_name=None, color='pod'):

--- a/commands/python/project/project_conf.py
+++ b/commands/python/project/project_conf.py
@@ -26,11 +26,10 @@ class ProjectConf(object):
     CONFIG_NAME = 'lamp.json'
 
     CONTENT_EXAMPLE = {
-        "name": "<project_name>",
-        "build_docker": ["./commands/build.bash"],
-        "helm_chart": ["./builds/<project_name>"],
-        "docker_images": ["img1", "img2", "img3"],
-        "commands": {"cmd": {"version": 2}},
+        'name': '<project_name>',
+        'build_docker': ['./commands/build.bash'],
+        'helm_chart': ['./builds/<project_name>'],
+        'docker_images': ['img1', 'img2', 'img3']
     }
 
     @classmethod
@@ -79,11 +78,7 @@ class ProjectConf(object):
 
     @property
     def helm_path(self):
-        return abspath(os.path.join(self.path, self.lamp_content["helm_chart"]))
-
-    @property
-    def commands_config(self):
-        return search("commands", self.lamp_content)
+        return abspath(os.path.join(self.path, self.lamp_content['helm_chart']))
 
     def get_docker_images(self):
         images = search('docker_images', self.lamp_content)

--- a/commands/python/project/project_conf.py
+++ b/commands/python/project/project_conf.py
@@ -26,10 +26,11 @@ class ProjectConf(object):
     CONFIG_NAME = 'lamp.json'
 
     CONTENT_EXAMPLE = {
-        'name': '<project_name>',
-        'build_docker': ['./commands/build.bash'],
-        'helm_chart': ['./builds/<project_name>'],
-        'docker_images': ['img1', 'img2', 'img3']
+        "name": "<project_name>",
+        "build_docker": ["./commands/build.bash"],
+        "helm_chart": ["./builds/<project_name>"],
+        "docker_images": ["img1", "img2", "img3"],
+        "commands": {"cmd": {"version": 2}},
     }
 
     @classmethod
@@ -78,7 +79,11 @@ class ProjectConf(object):
 
     @property
     def helm_path(self):
-        return abspath(os.path.join(self.path, self.lamp_content['helm_chart']))
+        return abspath(os.path.join(self.path, self.lamp_content["helm_chart"]))
+
+    @property
+    def commands_config(self):
+        return search("commands", self.lamp_content)
 
     def get_docker_images(self):
         images = search('docker_images', self.lamp_content)


### PR DESCRIPTION
The `commands-base:2.0.0` image moves the `command.py` script to a new location and name:
`/usr/local/bin/aladdin_command`. It also assumes responsibility for ensuring that it is executable so
aladdin can just invoke the script or program. This is to allow developers to mount their host files
into their command containers at `/code` without stomping on this necessary script.

Projects that wish to move to the new `commands-base:2.0.0` image should update their commands'
Dockerfiles to derive from this image. Aladdin will check for the existence of an executable named
`aladdin_command` on the `PATH` before falling back to the previous behavior.

If one wishes to use an alternative implementation of the command script provided by
`commands-base:2.0.0`, one only needs to create an executable named `aladdin_command` on their
image's `PATH` that accepts the same parameter's as the default implementation in
`commands-base:2.0.0`. (from #26)

See fivestars-os/commands-base#3 for further details.