### PR TITLE
[ALDN-190] Add DNS name information to helm values for use in templates

### DIFF
--- a/.jira
+++ b/.jira
@@ -1,0 +1,4 @@
+[project]
+	key = ALDN
+[project "ALDN"]
+	id = 12702

--- a/.jira
+++ b/.jira
@@ -1,4 +1,0 @@
-[project]
-	key = ALDN
-[project "ALDN"]
-	id = 12702

--- a/commands/python/command/deploy.py
+++ b/commands/python/command/deploy.py
@@ -78,6 +78,7 @@ def deploy(
         pr = PublishRules()
         helm = Helm()
         cr = cluster_rules(namespace=namespace)
+        global_cr = cluster_rules(namespace=cr.global_namespace)
         helm_path = "{}/{}".format(tmpdirname, project)
         hr = HelmRules(cr, project)
         git_account = load_git_configs()["account"]
@@ -101,11 +102,14 @@ def deploy(
         # Values precedence is command < cluster rules < --set-override-values
         # Deploy command values
         values = {
-            "service.globalCertificateDNS": cr.global_certificate_dns,
-            "service.globalCertificateHostname": cr.global_certificate_dns.strip("*."),
+            "service.rootCertificateDNS": cr.root_certificate_dns,
+            "service.rootCertificateHostname": cr.root_certificate_dns.strip("*."),
+            "service.rootCertificateArn": cr.get_certificate_arn(get_root=True),
+            "service.globalCertificateDNS": global_cr.certificate_dns,
+            "service.globalCertificateHostname": global_cr.certificate_dns.strip("*."),
+            "service.globalCertificateArn": global_cr.get_certificate_arn(),
             "service.certificateDNS": cr.certificate_dns,
             "service.certificateHostname": cr.certificate_dns.strip("*."),
-            "service.globalCertificateArn": cr.get_certificate_arn(get_global=True),
             "service.certificateArn": cr.get_certificate_arn(),
             "deploy.ecr": pr.docker_registry,
         }

--- a/commands/python/command/deploy.py
+++ b/commands/python/command/deploy.py
@@ -101,6 +101,11 @@ def deploy(
         # Values precedence is command < cluster rules < --set-override-values
         # Deploy command values
         values = {
+            "service.globalCertificateDNS": cr.global_certificate_dns,
+            "service.globalCertificateHostname": cr.global_certificate_dns.strip("*."),
+            "service.certificateDNS": cr.certificate_dns,
+            "service.certificateHostname": cr.certificate_dns.strip("*."),
+            "service.globalCertificateArn": cr.get_certificate_arn(get_global=True),
             "service.certificateArn": cr.get_certificate_arn(),
             "deploy.ecr": pr.docker_registry,
         }

--- a/commands/python/command/get_certificate.py
+++ b/commands/python/command/get_certificate.py
@@ -9,12 +9,19 @@ def parse_args(sub_parser):
     )
     subparser.set_defaults(func=get_certificate_args)
     add_namespace_argument(subparser)
+    subparser.add_argument(
+        "--global",
+        "-g",
+        action="store_true",
+        dest="get_global",
+        help='Get the certificate arn for the cluster\'s "global" namespace',
+    )
 
 
 def get_certificate_args(args):
-    get_certificate(args.namespace)
+    get_certificate(args.namespace, get_global=args.get_global)
 
 
-def get_certificate(namespace):
+def get_certificate(namespace, get_global):
     cr = cluster_rules(namespace=namespace)
-    return cr.get_certificate_arn()
+    return cr.get_certificate_arn(get_global=get_global)

--- a/commands/python/command/get_certificate.py
+++ b/commands/python/command/get_certificate.py
@@ -16,12 +16,21 @@ def parse_args(sub_parser):
         dest="get_global",
         help='Get the certificate arn for the cluster\'s "global" namespace',
     )
+    subparser.add_argument(
+        "--root",
+        "-r",
+        action="store_true",
+        dest="get_root",
+        help="Get the certificate arn for the cluster's un-namespaced domain name",
+    )
 
 
 def get_certificate_args(args):
-    get_certificate(args.namespace, get_global=args.get_global)
+    get_certificate(args.namespace, get_global=args.get_global, get_root=args.get_root)
 
 
-def get_certificate(namespace, get_global):
+def get_certificate(namespace, get_global, get_root):
     cr = cluster_rules(namespace=namespace)
-    return cr.get_certificate_arn(get_global=get_global)
+    if get_global:
+        cr = cluster_rules(namespace=cr.global_namespace)
+    return cr.get_certificate_arn(get_root=get_root)

--- a/commands/python/libs/aws/certificate.py
+++ b/commands/python/libs/aws/certificate.py
@@ -23,7 +23,7 @@ def search_certificate_arn(boto_session, dns_name):
 
     if len(list_cert) == 1:
         arn_res = list_cert[0]["CertificateArn"]
-        log.info("Found ISSUED certficate %s", arn_res)
+        log.info("Found ISSUED certificate %s for %s", arn_res, dns_name)
         return arn_res
 
     if len(list_cert) == 0:


### PR DESCRIPTION
In some situations it is helpful for the templates to be able to use the domain name at which the
service will be reachable. One use case is the upcoming Ambassador `Mapping` CRDs we will be
using for edge-authenticated API calls to our services.

Additionally, we need to provide not just the namespaced service hostname, but also one for
the new concept of the "global" namespace. By default, this will be the `default` namespace but
can be overriden by providing the `service_global_namespace` value in the cluster's aladdin config.
This global hostname is useful for identifying services that are not specific to a certain namespace,
but instead exist outside of those and are common to all services in the cluster.

Finally, making the "root" hostname and arn info is useful, too.

All of these hostname values are calculateable in the same manner as the existing
`service.certificateArn` value. If the `service_dns_suffix` value is defined in the cluster's aladdin
config, it will be used for both the namespace hostname as well as the global hostname.

Ultimately, we are adding these values to the deploy-time `.Values` payload:
```
service.rootCertificateDNS
service.rootCertificateHostname
service.rootCertificateArn
service.globalCertificateDNS
service.globalCertificateHostname
service.globalCertificateArn
service.certificateDNS
service.certificateHostname
```
[ALDN-190](https://fivestars.atlassian.net/browse/ALDN-190)