### PR TITLE
[ALDN-192] Fix chown of WORKDIR to USER when publishing

### DIFF
--- a/lib/build-components/build_components/templates/python/Dockerfile.j2
+++ b/lib/build-components/build_components/templates/python/Dockerfile.j2
@@ -96,10 +96,15 @@ RUN chown {{build_info.user_info.chown}} {{build_info.workdir}}
 # Ensure WORKDIR is on the PYTHONPATH
 ENV PYTHONPATH={{build_info.workdir}}${PYTHONPATH:+:$PYTHONPATH}
 
+{% if build_info.user_info.create %}
+# Switch to the unprivileged user account
+USER {{build_info.user_info.name}}
+{% endif %}
+
 {% if build_info.dev %}
 {#
-    This must be done after the user directory is created, as poetry expects to
-    be installed under the current user's home directory.
+    This must be done after the user directory is created and switched to,
+    as poetry expects to be installed under the current user's home directory.
 #}
 ####################################################################################################
 # Install poetry

--- a/lib/build-components/build_components/templates/python/macros.j2
+++ b/lib/build-components/build_components/templates/python/macros.j2
@@ -170,9 +170,6 @@ RUN groupadd -f {{user_info.group}} \
  && rm -rf /var/lib/apt/lists/* \
  && echo >> /etc/sudoers "{{user_info.name}} ALL=(ALL) NOPASSWD: ALL"
 {% endif %}
-
-# Switch to the unprivileged user account
-USER {{user_info.name}}
 {% endmacro %}
 
 


### PR DESCRIPTION
We need to do the `chown` before switching the `USER`.

[ALDN-192](https://fivestars.atlassian.net/browse/ALDN-192)