### PR TITLE
[ALDN-189] Add edge tools to aladdin image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 *.pyc
 *.DS_Store
+.githooks/.collections

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 
 *.pyc
 *.DS_Store
-.githooks/.collections

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,6 @@ ARG HELM_VERSION=2.16.1
 RUN	curl -L -o- https://storage.googleapis.com/kubernetes-helm/helm-v$HELM_VERSION-linux-amd64.tar.gz | tar -zxvf - && cp linux-amd64/helm \
 	/bin/helm && chmod 755 /bin/helm && helm init --client-only
 
-# Install helm 3
-ARG HELM_3_VERSION=3.2.4
-RUN curl -L -o- https://get.helm.sh/helm-v${HELM_3_VERSION}-linux-amd64.tar.gz | tar -zxvf - \
- && cp linux-amd64/helm /usr/local/bin/helm3 \
- && rm -r linux-amd64
-
 ARG KOPS_VERSION=1.15.0
 RUN	curl -L -o /bin/kops https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION/kops-linux-amd64 \
 	&& chmod 755 /bin/kops
@@ -60,7 +54,7 @@ ENV PATH="/root/.poetry/bin:${PATH}"
 COPY poetry.toml /root/.config/pypoetry/config.toml
 
 # Add datawire helm repo
-RUN helm3 repo add datawire https://www.getambassador.io
+RUN helm repo add datawire https://www.getambassador.io
 
 WORKDIR /root/aladdin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,31 +24,43 @@ RUN ln -fs /usr/bin/python3 /usr/local/bin/python \
 RUN go get -u -v sigs.k8s.io/aws-iam-authenticator/cmd/aws-iam-authenticator
 
 # Update all needed tool versions here
-ARG DOCKER_VERSION=18.09.7
-ARG KUBE_VERSION=1.15.6
-ARG HELM_VERSION=2.16.1
-ARG KOPS_VERSION=1.15.0
-ARG POETRY_VERSION=1.0.9
 
+ARG DOCKER_VERSION=18.09.7
 RUN curl -L -o- https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz | tar -zxvf - && cp docker/docker \
     /usr/bin/docker && chmod 755 /usr/bin/docker
 
+ARG KUBE_VERSION=1.15.6
 RUN	curl -L -o /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/amd64/kubectl \
 	&& chmod 755 /bin/kubectl
 
+ARG HELM_VERSION=2.16.1
 RUN	curl -L -o- https://storage.googleapis.com/kubernetes-helm/helm-v$HELM_VERSION-linux-amd64.tar.gz | tar -zxvf - && cp linux-amd64/helm \
 	/bin/helm && chmod 755 /bin/helm && helm init --client-only
 
+# Install helm 3
+ARG HELM_3_VERSION=3.2.4
+RUN curl -L -o- https://get.helm.sh/helm-v${HELM_3_VERSION}-linux-amd64.tar.gz | tar -zxvf - \
+ && cp linux-amd64/helm /usr/local/bin/helm3 \
+ && rm -r linux-amd64
+
+ARG KOPS_VERSION=1.15.0
 RUN	curl -L -o /bin/kops https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION/kops-linux-amd64 \
 	&& chmod 755 /bin/kops
+
+# Install edgectl
+RUN curl -fL https://metriton.datawire.io/downloads/linux/edgectl -o /usr/local/bin/edgectl && chmod a+x /usr/local/bin/edgectl
 
 # On some images "sh" is aliased to "dash" which does not support "set -o pipefail".
 # We use the "exec" form of RUN to delegate this command to bash instead.
 # This is all because we have a pipe in this command and we wish to fail the build
 # if any command in the pipeline fails.
+ARG POETRY_VERSION=1.0.10
 RUN ["/bin/bash", "-c", "set -o pipefail && curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python"]
 ENV PATH="/root/.poetry/bin:${PATH}"
 COPY poetry.toml /root/.config/pypoetry/config.toml
+
+# Add datawire helm repo
+RUN helm3 repo add datawire https://www.getambassador.io
 
 WORKDIR /root/aladdin
 


### PR DESCRIPTION
This adds:

* the Datawire helm repository to `helm` to enable deploying the Ambassador edge stack
* `edgectl` [(link)](https://www.getambassador.io/docs/latest/topics/using/edgectl/edge-control/) for managing an Ambassador API gateway

[ALDN-189](https://fivestars.atlassian.net/browse/ALDN-189)
