### PR TITLE
[ALDN-193] Support deploying a specific chart in a project

### DIFF
--- a/commands/python/command/deploy.py
+++ b/commands/python/command/deploy.py
@@ -21,6 +21,9 @@ def parse_args(sub_parser):
     subparser.add_argument("project", help="which project to deploy")
     subparser.add_argument("git_ref", help="which git hash or tag or branch to deploy")
     subparser.add_argument(
+        "--chart", help="which chart in the project to deploy, defaults to the project name"
+    )
+    subparser.add_argument(
         "--dry-run",
         "-d",
         action="store_true",
@@ -54,6 +57,7 @@ def deploy_args(args):
         args.project,
         args.git_ref,
         args.namespace,
+        args.chart,
         args.dry_run,
         args.force,
         args.force_helm,
@@ -66,6 +70,7 @@ def deploy(
     project,
     git_ref,
     namespace,
+    chart=None,
     dry_run=False,
     force=False,
     force_helm=False,
@@ -78,7 +83,7 @@ def deploy(
         pr = PublishRules()
         helm = Helm()
         cr = cluster_rules(namespace=namespace)
-        helm_path = "{}/{}".format(tmpdirname, project)
+        helm_chart_path = "{}/{}".format(tmpdirname, chart or project)
         hr = HelmRules(cr, project)
         git_account = load_git_configs()["account"]
         repo = repo or project
@@ -93,7 +98,7 @@ def deploy(
             )
             sys.exit(1)
 
-        helm.pull_package(project, pr, git_ref, tmpdirname)
+        helm.pull_packages(project, pr, git_ref, tmpdirname)
 
         # We need to use --set-string in case the git ref is all digits
         helm_args = ["--set-string", f"deploy.imageTag={git_ref}"]
@@ -111,10 +116,18 @@ def deploy(
         values.update(value_overrides)
 
         if dry_run:
-            helm.dry_run(hr, helm_path, cr.cluster_name, namespace, helm_args=helm_args, **values)
+            helm.dry_run(
+                hr, helm_chart_path, cr.cluster_name, namespace, helm_args=helm_args, **values
+            )
         else:
             helm.start(
-                hr, helm_path, cr.cluster_name, namespace, force_helm, helm_args=helm_args, **values
+                hr,
+                helm_chart_path,
+                cr.cluster_name,
+                namespace,
+                force_helm,
+                helm_args=helm_args,
+                **values,
             )
             sync_ingress.sync_ingress(namespace)
             sync_dns.sync_dns(namespace)

--- a/commands/python/command/deploy.py
+++ b/commands/python/command/deploy.py
@@ -84,7 +84,7 @@ def deploy(
         helm = Helm()
         cr = cluster_rules(namespace=namespace)
         helm_chart_path = "{}/{}".format(tmpdirname, chart or project)
-        hr = HelmRules(cr, project)
+        hr = HelmRules(cr, chart or project)
         git_account = load_git_configs()["account"]
         repo = repo or project
         git_url = f"git@github.com:{git_account}/{repo}.git"
@@ -106,8 +106,10 @@ def deploy(
         # Values precedence is command < cluster rules < --set-override-values
         # Deploy command values
         values = {
+            "project.name": project,
             "service.certificateArn": cr.get_certificate_arn(),
             "deploy.ecr": pr.docker_registry,
+            "deploy.namespace": namespace,
         }
         # Update with cluster rule values
         values.update(cr.values)

--- a/commands/python/command/restart.py
+++ b/commands/python/command/restart.py
@@ -11,7 +11,7 @@ def parse_args(sub_parser):
         "--chart",
         action="append",
         dest="charts",
-        help="Only start these charts (may be specified multiple times)",
+        help="Start only these charts (may be specified multiple times)",
     )
     subparser.add_argument(
         "--with-mount",
@@ -26,5 +26,5 @@ def restart_args(args):
 
 
 def restart(namespace, charts, with_mount):
-    stop.stop(namespace)
+    stop.stop(namespace, charts)
     start.start(namespace, charts, False, with_mount)

--- a/commands/python/command/restart.py
+++ b/commands/python/command/restart.py
@@ -8,6 +8,12 @@ def parse_args(sub_parser):
     subparser.set_defaults(func=restart_args)
     add_namespace_argument(subparser)
     subparser.add_argument(
+        "--chart",
+        action="append",
+        dest="charts",
+        help="Only start these charts (may be specified multiple times)",
+    )
+    subparser.add_argument(
         "--with-mount",
         "-m",
         action="store_true",
@@ -16,9 +22,9 @@ def parse_args(sub_parser):
 
 
 def restart_args(args):
-    restart(args.namespace, args.with_mount)
+    restart(args.namespace, args.charts, args.with_mount)
 
 
-def restart(namespace, with_mount):
+def restart(namespace, charts, with_mount):
     stop.stop(namespace)
-    start.start(namespace, False, with_mount)
+    start.start(namespace, charts, False, with_mount)

--- a/commands/python/command/rollback.py
+++ b/commands/python/command/rollback.py
@@ -10,21 +10,24 @@ def parse_args(sub_parser):
     subparser = sub_parser.add_parser("rollback", help="Go back to a previous deployment")
     subparser.set_defaults(func=rollback_args)
     add_namespace_argument(subparser)
-    subparser.add_argument("project", help="which project to undeploy")
+    subparser.add_argument("project", help="which project to roll back")
+    subparser.add_argument(
+        "--chart", help="which chart in the project to roll back, defaults to the project name"
+    )
     subparser.add_argument(
         "--num-versions", type=int, default=1, help="how many versions to rollback, defaults to 1"
     )
 
 
 def rollback_args(args):
-    rollback(args.project, args.num_versions, args.namespace)
+    rollback(args.project, args.num_versions, args.namespace, args.chart)
 
 
-def rollback(project, num_versions, namespace):
+def rollback(project, num_versions, namespace, chart=None):
     helm = Helm()
 
     cr = cluster_rules(namespace=namespace)
-    hr = HelmRules(cr, project)
+    hr = HelmRules(cr, chart or project)
 
     helm.rollback_relative(hr, num_versions)
 

--- a/commands/python/command/start.py
+++ b/commands/python/command/start.py
@@ -77,17 +77,9 @@ def start(
     # Values precedence is command < cluster rules < --set-override-values
     # Start command values
     values = {
-        "project.name": pc.name,
-        "service.clusterDomainName": cr.cluster_domain_name_suffix,
-        "service.clusterCertificateScope": cr.cluster_certificate_scope,
-        "service.clusterCertificateArn": cr.cluster_certificate_arn,
-        "service.domainName": cr.service_domain_name_suffix,
-        "service.certificateScope": cr.service_certificate_scope,
-        "service.certificateArn": cr.service_certificate_arn,
-        "deploy.imageTag": "local",
-        "deploy.mountPath": pc.mount_path,
-        "deploy.namespace": namespace,
         "deploy.withMount": with_mount,
+        "deploy.mountPath": pc.mount_path,
+        "project.name": pc.name,
     }
     # Update with cluster rule values
     values.update(cr.values)

--- a/commands/python/command/start.py
+++ b/commands/python/command/start.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import os
+
 from arg_tools import add_namespace_argument
 from cluster_rules import cluster_rules
 from command import sync_ingress, sync_dns
@@ -11,6 +13,12 @@ def parse_args(sub_parser):
     subparser = sub_parser.add_parser("start", help="Start the helm chart in local")
     subparser.set_defaults(func=start_args)
     add_namespace_argument(subparser)
+    subparser.add_argument(
+        "--chart",
+        action="append",
+        dest="charts",
+        help="Only start these charts (may be specified multiple times)",
+    )
     subparser.add_argument(
         "--dry-run",
         "-d",
@@ -37,10 +45,24 @@ def parse_args(sub_parser):
 
 
 def start_args(args):
-    start(args.namespace, args.dry_run, args.with_mount, args.force_helm, args.set_override_values)
+    start(
+        args.namespace,
+        args.charts,
+        args.dry_run,
+        args.with_mount,
+        args.force_helm,
+        args.set_override_values,
+    )
 
 
-def start(namespace, dry_run=False, with_mount=False, force_helm=False, set_override_values=None):
+def start(
+    namespace,
+    charts=None,
+    dry_run=False,
+    with_mount=False,
+    force_helm=False,
+    set_override_values=None,
+):
     if set_override_values is None:
         set_override_values = []
     pc = ProjectConf()
@@ -48,6 +70,10 @@ def start(namespace, dry_run=False, with_mount=False, force_helm=False, set_over
 
     cr = cluster_rules(namespace=namespace)
     hr = HelmRules(cr, pc.name)
+
+    # Start each of the project's charts
+    if charts is None:
+        charts = [os.path.basename(chart_path) for chart_path in pc.get_helm_chart_paths()]
 
     # Values precedence is command < cluster rules < --set-override-values
     # Start command values
@@ -62,9 +88,11 @@ def start(namespace, dry_run=False, with_mount=False, force_helm=False, set_over
     value_overrides = {k: v for k, v in (value.split("=") for value in set_override_values)}
     values.update(value_overrides)
 
-    if dry_run:
-        helm.dry_run(hr, pc.helm_path, cr.cluster_name, namespace, **values)
-    else:
-        helm.start(hr, pc.helm_path, cr.cluster_name, namespace, force_helm, **values)
-        sync_ingress.sync_ingress(namespace)
-        sync_dns.sync_dns(namespace)
+    for chart_path in pc.get_helm_chart_paths():
+        if os.path.basename(chart_path) in charts:
+            if dry_run:
+                helm.dry_run(hr, chart_path, cr.cluster_name, namespace, **values)
+            else:
+                helm.start(hr, chart_path, cr.cluster_name, namespace, force_helm, **values)
+                sync_ingress.sync_ingress(namespace)
+                sync_dns.sync_dns(namespace)

--- a/commands/python/command/start.py
+++ b/commands/python/command/start.py
@@ -100,14 +100,14 @@ def start(
         for chart_path in pc.get_helm_chart_paths():
             chart_name = os.path.basename(chart_path)
             if chart_name in charts:
-                hr = HelmRules(cr, chart_name or pc.name)
+                hr = HelmRules(cr, chart_name)
                 if dry_run:
                     helm.dry_run(hr, chart_path, cr.cluster_name, namespace, **values)
                 else:
                     helm.start(hr, chart_path, cr.cluster_name, namespace, force_helm, **values)
                     sync_required = True
     finally:
-        # Sync if any helm.start() call succeeded, even if a subsequent one fails
+        # Sync if any helm.start() call succeeded, even if a subsequent one failed
         if sync_required:
             sync_ingress.sync_ingress(namespace)
             sync_dns.sync_dns(namespace)

--- a/commands/python/command/stop.py
+++ b/commands/python/command/stop.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import os
+
 from arg_tools import add_namespace_argument
 from cluster_rules import cluster_rules
 from command import sync_ingress, sync_dns
@@ -11,20 +13,38 @@ def parse_args(sub_parser):
     subparser = sub_parser.add_parser("stop", help="Remove the helm chart in local")
     subparser.set_defaults(func=stop_args)
     add_namespace_argument(subparser)
+    subparser.add_argument(
+        "--chart",
+        action="append",
+        dest="charts",
+        help="Stop only these charts (may be specified multiple times)",
+    )
 
 
 def stop_args(args):
-    stop(args.namespace)
+    stop(args.namespace, args.charts)
 
 
-def stop(namespace):
+def stop(namespace, charts):
     pc = ProjectConf()
     helm = Helm()
 
     cr = cluster_rules(namespace=namespace)
-    hr = HelmRules(cr, pc.name)
 
-    helm.stop(hr)
+    if charts is None:
+        # Stop each of the project's charts
+        charts = [os.path.basename(chart_path) for chart_path in pc.get_helm_chart_paths()]
 
-    sync_ingress.sync_ingress(namespace)
-    sync_dns.sync_dns(namespace)
+    sync_required = False
+    try:
+        for chart_path in pc.get_helm_chart_paths():
+            chart_name = os.path.basename(chart_path)
+            if chart_name in charts:
+                hr = HelmRules(cr, chart_name or pc.name)
+                helm.stop(hr)
+                sync_required = True
+    finally:
+        # Sync if any helm.start() call succeeded, even if a subsequent one fails
+        if sync_required:
+            sync_ingress.sync_ingress(namespace)
+            sync_dns.sync_dns(namespace)

--- a/commands/python/command/stop.py
+++ b/commands/python/command/stop.py
@@ -40,11 +40,11 @@ def stop(namespace, charts):
         for chart_path in pc.get_helm_chart_paths():
             chart_name = os.path.basename(chart_path)
             if chart_name in charts:
-                hr = HelmRules(cr, chart_name or pc.name)
+                hr = HelmRules(cr, chart_name)
                 helm.stop(hr)
                 sync_required = True
     finally:
-        # Sync if any helm.start() call succeeded, even if a subsequent one fails
+        # Sync if any helm.stop() call succeeded, even if a subsequent one failed
         if sync_required:
             sync_ingress.sync_ingress(namespace)
             sync_dns.sync_dns(namespace)

--- a/commands/python/command/undeploy.py
+++ b/commands/python/command/undeploy.py
@@ -13,17 +13,20 @@ def parse_args(sub_parser):
     subparser.set_defaults(func=undeploy_args)
     add_namespace_argument(subparser)
     subparser.add_argument("project", help="which project to undeploy")
+    subparser.add_argument(
+        "--chart", help="which chart in the project to undeploy, defaults to the project name"
+    )
 
 
 def undeploy_args(args):
-    undeploy(args.project, args.namespace)
+    undeploy(args.project, args.namespace, args.chart)
 
 
-def undeploy(project, namespace):
+def undeploy(project, namespace, chart=None):
     helm = Helm()
 
     cr = cluster_rules(namespace=namespace)
-    hr = HelmRules(cr, project)
+    hr = HelmRules(cr, chart or project)
 
     helm.stop(hr)
 

--- a/commands/python/helm_rules.py
+++ b/commands/python/helm_rules.py
@@ -1,12 +1,12 @@
 class HelmRules(object):
-    def __init__(self, cluster_rules, project_name):
+    def __init__(self, cluster_rules, chart_name):
         self._cluster_rules = cluster_rules
-        self._project_name = project_name
+        self._chart_name = chart_name
 
     @property
     def release_name(self):
         # TODO there is a limit on the name size, we should check that
-        return "{0}-{1}".format(self._project_name, self._cluster_rules.namespace)
+        return "{0}-{1}".format(self._chart_name, self._cluster_rules.namespace)
 
     def helm_values(self):
         return dict()

--- a/commands/python/libs/k8s/helm.py
+++ b/commands/python/libs/k8s/helm.py
@@ -151,12 +151,16 @@ class Helm(object):
             helm_args = []
         if force:
             helm_args.append("--force")
+        logger.info("Installing release %s in namespace %s", helm_rules.release_name, namespace)
         return self._run(helm_rules, chart_path, cluster_name, namespace, helm_args, **values)
 
     def dry_run(self, helm_rules, chart_path, cluster_name, namespace, helm_args=None, **values):
         if helm_args is None:
             helm_args = []
         helm_args += ["--dry-run", "--debug"]
+        logger.info(
+            "Dry run installing release %s in namespace %s", helm_rules.release_name, namespace
+        )
         return self._run(helm_rules, chart_path, cluster_name, namespace, helm_args, **values)
 
     def _run(self, helm_rules, chart_path, cluster_name, namespace, helm_args=None, **values):
@@ -180,5 +184,5 @@ class Helm(object):
         if helm_args:
             command.extend(helm_args)
 
-        logger.info("Executing: " + " ".join(command))
+        logger.info("Executing: %s", " ".join(command))
         subprocess.run(command, check=True)

--- a/commands/python/libs/k8s/helm.py
+++ b/commands/python/libs/k8s/helm.py
@@ -3,15 +3,16 @@ import os
 import subprocess
 import logging
 
+import yaml
 from botocore.exceptions import ClientError
-from os.path import join, dirname, expanduser
+from os.path import join, expanduser
 
 logger = logging.getLogger(__name__)
 
 
 class Helm(object):
-    PACKAGE_PATH = "helm_charts/0.0.0/{project_name}/{git_ref}/{project_name}.{git_ref}.tgz"
-    VALUE_PATH = "helm_charts/0.0.0/{project_name}/{git_ref}/values.{values_name}.yaml"
+    PACKAGE_DIR_PATH = "helm_charts/0.0.0/{project_name}/{git_ref}/"
+    PACKAGE_PATH = "helm_charts/0.0.0/{project_name}/{git_ref}/{chart_name}.{git_ref}.tgz"
 
     @property
     def helm_home(self):
@@ -21,7 +22,7 @@ class Helm(object):
         # We need to have local helm initialized for it to works
         subprocess.check_call(["helm", "init", "--client-only"])
 
-    def publish(self, name, publish_rules, helm_path, hash):
+    def publish(self, project_name, publish_rules, helm_path, hash):
 
         # HelmContext = namedtuple('HelmContext', ['chart_home', 'values_files', 'name'])
 
@@ -30,33 +31,53 @@ class Helm(object):
         logger.info("Building package")
         self.init()
 
-        subprocess.check_call(
-            ["helm", "package", "--version", version, name], cwd=dirname(helm_path)
-        )
-        package_path = join(dirname(helm_path), "{}-{}.tgz".format(name, version))
-        bucket_path = self.PACKAGE_PATH.format(project_name=name, git_ref=hash)
+        charts_dir, chart_name = os.path.split(helm_path)
 
-        logger.info("Uploading chart")
+        subprocess.check_call(["helm", "package", "--version", version, chart_name], cwd=charts_dir)
+
+        package_path = join(charts_dir, "{}-{}.tgz".format(chart_name, version))
+        bucket_path = self.PACKAGE_PATH.format(
+            project_name=project_name, chart_name=chart_name, git_ref=hash
+        )
+
+        logger.info("Uploading %s chart to %s", chart_name, bucket_path)
         publish_rules.s3_bucket.upload_file(package_path, bucket_path)
         os.remove(package_path)
 
-    def pull_package(self, project_name, publish_rules, git_ref, extract_dir):
-        extract_loc = "{}/{}.tgz".format(extract_dir, project_name)
-        try:
-            publish_rules.s3_bucket.download_file(
-                self.PACKAGE_PATH.format(project_name=project_name, git_ref=git_ref), extract_loc
+    def pull_packages(self, project_name, publish_rules, git_ref, extract_dir):
+        """
+        Retrieve all charts published for this project at this git_ref.
+
+        This will download all the published charts and extract them to extract_dir.
+
+        :param project_name: The name of the aladdin project being retrieved.
+        :param publish_rules: Details for accessing the S3 bucket.
+        :param git_ref: The version of the chart(s) to retrieve.
+        :param extract_dir: Where to place the downloaded charts.
+        """
+        # List the contents of the publish "directory" and find
+        # everything that looks like a chart.
+        package_keys = [
+            obj.key
+            for obj in publish_rules.s3_bucket.objects.filter(
+                Prefix=self.PACKAGE_DIR_PATH.format(project_name=project_name, git_ref=git_ref)
             )
-        except ClientError:
-            logger.error(
-                "Error downloading from S3: {}".format(
-                    self.PACKAGE_PATH.format(project_name=project_name, git_ref=git_ref)
-                )
-            )
-            raise
-        subprocess.check_call(["tar", "-xvzf", extract_loc, "-C", extract_dir])
+            if obj.key.endswith(f".{git_ref}.tgz")
+        ]
+
+        # Download the chart archives and extract the contents into their own chart sub-directories
+        for package_key in package_keys:
+            downloaded_package = join(extract_dir, os.path.basename(package_key))
+            try:
+                publish_rules.s3_bucket.download_file(package_key, downloaded_package)
+            except ClientError:
+                logger.error("Error downloading from S3: {}".format(package_key))
+                raise
+
+            subprocess.check_call(["tar", "-xvzf", downloaded_package, "-C", extract_dir])
+            os.remove(downloaded_package)
 
     def find_values(self, chart_path, cluster_name, namespace):
-
         values = []
 
         # Find all possible values yaml files for override in increasing priority

--- a/commands/python/project/project_conf.py
+++ b/commands/python/project/project_conf.py
@@ -81,10 +81,6 @@ class ProjectConf(object):
 
         subprocess.run(command, check=True, cwd=self.path, env=run_env)
 
-    @property
-    def helm_path(self):
-        return abspath(os.path.join(self.path, self.lamp_content["helm_chart"]))
-
     def get_docker_images(self):
         images = search("docker_images", self.lamp_content)
         if isinstance(images, str):

--- a/docs/deploy_cmd.md
+++ b/docs/deploy_cmd.md
@@ -1,8 +1,9 @@
 # Aladdin Deploy
-Deploy is one of aladdin's commands used for to deploy projects to non local environments. This command pulls a project's helm package from s3, sets the container images to the full ecr path with git ref as tag, and installs/upgrades the previously deployed project. This command can check the deployed hash against a given branch (set in your aladdin config) unless the `--force` option is supplied.  
+Deploy is one of aladdin's commands used to deploy projects to non local environments. This command pulls a project's helm package from s3, sets the container images to the full ecr path with the git ref as the tag, and installs/upgrades the previously deployed project. This command will check the deployed hash against a given branch (set in your aladdin config) unless the `--force` option is supplied.
 ```
 usage: aladdin deploy [-h] [--namespace NAMESPACE] [--dry-run] [--force]
                       [--repo REPO]
+                      [--chart CHART_NAME]
                       [--set-override-values SET_OVERRIDE_VALUES [SET_OVERRIDE_VALUES ...]]
                       project git_ref
 
@@ -20,8 +21,11 @@ optional arguments:
                         enabled on the cluster
   --force-helm          Have helm force resource update through
                         delete/recreate if needed
-  --repo REPO           which git repo to pull from, which should be used if
+  --repo REPO           Which git repo to pull from, which should be used if
                         it differs from chart name
+  --chart CHART_NAME    Which chart to deploy if your project defines more
+                        than a single chart in the lamp.json file, defaults
+                        to the project name
   --set-override-values SET_OVERRIDE_VALUES [SET_OVERRIDE_VALUES ...]
                         override values in the values file. Syntax: --set
                         key1=value1 key2=value2 ...
@@ -29,6 +33,7 @@ optional arguments:
 - Example: `aladdin -c DEV -n test deploy aladdin-demo 8d2j8f30bd`
 - Example: `aladdin -c PROD deploy aladdin-demo master`
 - Example: `aladdin -c DEV -n test deploy aladdin-demo 5a5e59b2f6 --set-override-values replicas=3 resources.cpu.request.enable=true`
+- Example: `aladdin -c DEV -n special deploy aladdin-demo 5a5e59b2f6 --chart aladdin-demo-special`
 
 Note: Although this command is primarily used for non local environments, you can still use it in minikube rather than using `aladdin start`. The benefit of this is that you are not required to have the project pulled locally. The cons of this is that you have to get the githash you want to deploy, and you cannot mount your host code in this method.
 

--- a/docs/restart_cmd.md
+++ b/docs/restart_cmd.md
@@ -1,13 +1,17 @@
 # Aladdin Restart
 Restart is one of aladdin's commands used for local development. This command is to be called from within an aladdin-compatible project repo. This command removes a project from your local environment, and then installs it back.  
 ```
-usage: aladdin restart [-h] [--namespace NAMESPACE] [--with-mount]
+usage: aladdin restart [-h] [--namespace NAMESPACE] [--with-mount] [--chart CHART_NAME]...
 
 optional arguments:
   -h, --help            show this help message and exit
   --namespace NAMESPACE, -n NAMESPACE
                         namespace name, defaults to default current :
                         [default]
+  --chart CHART_NAME    Restart only these charts (can be specified multiple times)
   --with-mount, -m      Mount user's host's project repo onto container
 ```
 Note that for `--with-mount` to work as expected, you will have to set up the necessary volume and volumeMounts as described in the aladdin demo project [here](https://github.com/fivestars-os/aladdin-demo/blob/master/docs/code_mounting.md).
+
+If the `--chart` option is not provided, all charts defined in the `lamp.json` file will be
+restarted.

--- a/docs/rollback_cmd.md
+++ b/docs/rollback_cmd.md
@@ -1,9 +1,10 @@
 # Aladdin Rollback
-Rollback is one of aladdin's commands used for to rollback deployments in non local environments. This command creates a new deployment revision which matches `--num-versions` versions previous to the current revision. 
+Rollback is used to rollback deployments in non local environments. This command creates a new deployment revision which matches `--num-versions` versions previous to the current revision.
 ```
 usage: aladdin rollback [-h] [--namespace NAMESPACE]
                         [--num-versions NUM_VERSIONS]
                         project
+                        [--chart CHART_NAME]
 
 positional arguments:
   project               which project to undeploy
@@ -15,7 +16,10 @@ optional arguments:
                         [default]
   --num-versions NUM_VERSIONS
                         how many versions to rollback, defaults to 1
+  --chart CHART_NAME    Which chart to roll back if your project defines more
+                        than a single chart in the lamp.json file, defaults
+                        to the project name
 ```
-- Example: `aladdin -c DEV -n test rollback aladdin-demo --num-versions 2` 
+- Example: `aladdin -c DEV -n test rollback aladdin-demo --num-versions 2`
 
 Note: that since rollback creates a new revision, calling rollback twice with --num-versions set to 1 (by default) will get you where you started rather than 2 revisions previous.

--- a/docs/start_cmd.md
+++ b/docs/start_cmd.md
@@ -2,6 +2,8 @@
 Start is one of aladdin's commands used for local development. This command is to be called from within an aladdin-compatible project repo. This command installs a project to your local environment. 
 ```
 usage: aladdin start [-h] [--namespace NAMESPACE] [--dry-run] [--with-mount]
+                     [--chart CHART_NAME]...
+                     [--force-helm]
                      [--set-override-values SET_OVERRIDE_VALUES [SET_OVERRIDE_VALUES ...]]
 
 optional arguments:
@@ -11,6 +13,7 @@ optional arguments:
                         [default]
   --dry-run, -d         Run the helm as test and don't actually run it
   --with-mount, -m      Mount user's host's project repo onto container
+  --chart CHART_NAME    Start only these charts (can be specified multiple times)
   --force-helm          Have helm force resource update through
                         delete/recreate if needed
   --set-override-values SET_OVERRIDE_VALUES [SET_OVERRIDE_VALUES ...]
@@ -18,3 +21,5 @@ optional arguments:
                         key1=value1 key2=value2 ...
 ```
 Note that for `--with-mount` to work as expected, you will have to set up the necessary volume and volumeMounts as described in the aladdin demo project [here](https://github.com/fivestars-os/aladdin-demo/blob/master/docs/code_mounting.md).
+
+If the `--chart` option is not provided, all charts defined in the `lamp.json` file will be started.

--- a/docs/stop_cmd.md
+++ b/docs/stop_cmd.md
@@ -1,11 +1,12 @@
 # Aladdin Stop
 Stop is one of aladdin's commands used for local development. This command is to be called from within an aladdin-compatible project repo. This command removes a project from your local environment. 
 ```
-usage: aladdin stop [-h] [--namespace NAMESPACE]
+usage: aladdin stop [-h] [--namespace NAMESPACE] [--chart CHART_NAME]
 
 optional arguments:
   -h, --help            show this help message and exit
   --namespace NAMESPACE, -n NAMESPACE
                         namespace name, defaults to default current :
                         [default]
+  --chart CHART_NAME    Stop only these charts (can be specified multiple times)
 ```

--- a/docs/undeploy_cmd.md
+++ b/docs/undeploy_cmd.md
@@ -1,7 +1,7 @@
 # Aladdin Undeploy
 Undeploy is one of aladdin's commands used to remove projects from non local environments. 
 ```
-usage: aladdin undeploy [-h] [--namespace NAMESPACE] project
+usage: aladdin undeploy [-h] [--namespace NAMESPACE] project [--chart CHART_NAME]
 
 positional arguments:
   project               which project to undeploy
@@ -11,5 +11,8 @@ optional arguments:
   --namespace NAMESPACE, -n NAMESPACE
                         namespace name, defaults to default current :
                         [default]
+  --chart CHART_NAME    Which chart to undeploy if your project defines more
+                        than a single chart in the lamp.json file, defaults
+                        to the project name
 ```
 - Example: `aladdin -c DEV -n test undeploy aladdin-demo`


### PR DESCRIPTION
In some situations, a project may need to maintain two or more charts. `aladdin start`, `aladdin publish`
and `aladdin deploy` all currently support an all-or-nothing approach to their respective operations.
We should be able to specify which chart we wish to deploy.

This adds the `--chart` option to the `deploy', 'restart', 'rollback', 'start', 'stop', and 'undeploy' commands.
The default behavior for `start`, `stop` and `restart` is to perform the operation on all charts if not
otherwise specified. For the others, it will default to using the project's name (which prior to this was a
hard-coded assumption) and will only ever use a single chart per invocation. Multiple invocations are
required to deploy multiple charts.

This also adds the `.Values.project.name` and `.Values.deploy.namespace` values to the helm templating
process during the `start`, `restart` and `deploy` commands.

`aladdin publish` will now push all charts individually to S3 (there is no need to specify the chart to publish)
and `aladdin deploy` now pulls all charts down before deciding which one to publish according to the
`--chart` value.


#### TODO:
- [x] Add `--chart` option to remaining related commands, too
- [x] Update docs

[ALDN-193](https://fivestars.atlassian.net/browse/ALDN-193)