### PR TITLE
[ISSUE-63] Allow cluster name with dashes

### DIFF
--- a/aladdin.sh
+++ b/aladdin.sh
@@ -54,7 +54,7 @@ function get_plugin_dir() {
 
 # Check for cluster name aliases and alias them accordingly
 function check_cluster_alias() {
-    cluster_alias=$(jq -r ".cluster_aliases.$CLUSTER_CODE" "$ALADDIN_CONFIG_FILE")
+    cluster_alias=$(jq -r --arg key "$CLUSTER_CODE" '.cluster_aliases[$key]' "$ALADDIN_CONFIG_FILE")
     if [[ $cluster_alias != null ]]; then
         export CLUSTER_CODE=$cluster_alias
     fi


### PR DESCRIPTION
When I use cluster name like docker-desktop, it fails with 
```
jq: error: desktop/0 is not defined at <top-level>, line 1:
.cluster_aliases.docker-desktop
jq: 1 compile error
```
This PR is to fix that problem.

https://github.com/fivestars-os/aladdin/issues/63