### PR TITLE
[ISSUE-66] Option to ask aladdin to not manage minikube

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ You will now need to [create your aladdin configuration](./docs/create_aladdin_c
 
     $ aladdin config set config_dir /path/to/aladdin/configuration
 
+### Manage configuration
+#### minikube
+aladdin uses minikube to get access to docker functionality.
+It also sets up minikube (file sharing etc) so that you can deploy to minikube.
+
+But you may not need that if this applies to your situation:
+1. You already have docker installed (say using docker.app on mac for example) 
+1. You are using an alternative to minikube (like docker-desktop or kind, etc) for local cluster or
+1. You are using aladdin to connect to a remote cluster (like staging, prod etc)
+
+Then run:
+
+```
+aladdin config set manage.minikube false
+```
+
 ### VM Configuration
 Currently, the following parameters are configurable:
  * memory: By default, we create a minikube vm with 4096MB (4GB) of memory.  To change the size of the vm we create to e.g. 8GB, you may run:

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -64,7 +64,7 @@ function get_plugin_dir() {
 
 function get_manage_minikube() {
     if [[ -f "$HOME/.aladdin/config/config.json" ]]; then
-        MANAGE_MINIKUBE=$(jq -r .manage_minikube $HOME/.aladdin/config/config.json)
+        MANAGE_MINIKUBE=$(jq -r .manage.minikube $HOME/.aladdin/config/config.json)
         if [[ "$MANAGE_MINIKUBE" == null ]]; then
             MANAGE_MINIKUBE=true
         fi

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -62,6 +62,15 @@ function get_plugin_dir() {
     fi
 }
 
+function get_manage_minikube() {
+    if [[ -f "$HOME/.aladdin/config/config.json" ]]; then
+        MANAGE_MINIKUBE=$(jq -r .manage_minikube $HOME/.aladdin/config/config.json)
+        if [[ "$MANAGE_MINIKUBE" == null ]]; then
+            MANAGE_MINIKUBE=true
+        fi
+    fi
+}
+
 # Check for cluster name aliases and alias them accordingly
 function check_cluster_alias() {
     cluster_alias=$(jq -r ".cluster_aliases.$CLUSTER_CODE" "$ALADDIN_CONFIG_FILE")
@@ -397,9 +406,6 @@ while [[ $# -gt 0 ]]; do
         --non-terminal)
             IS_TERMINAL=false
         ;;
-        --no-manage-minikube)
-            MANAGE_MINIKUBE=false
-        ;;
         --skip-prompts)
             SKIP_PROMPTS=true
         ;;
@@ -416,6 +422,7 @@ exec_host_command "$@"
 get_config_path
 get_plugin_dir
 exec_host_plugin "$@"
+get_manage_minikube
 check_cluster_alias
 check_and_handle_init
 set_cluster_helper_vars


### PR DESCRIPTION
minikube commands are executed with direct calls to `minikube`
and with helper function.

When --no-manage-minikube is set:
1. direct calls to `minikube` become no op.
2. helper function return right away if MANAGE_MINIKUBE is false

This change might seem hacky. But  aladdin.sh will have to be
rewritten first to make it easy to make these types of changes.

[ISSUE-66](https://github.com/fivestars-os/aladdin/issues/66)