### PR TITLE
[ALDN-204] Allow command to be provided directly to aladdin bash

### DIFF
--- a/aladdin.sh
+++ b/aladdin.sh
@@ -113,7 +113,7 @@ function check_and_handle_init() {
             eval "$repo_login_command"
         fi
         local aladdin_image="$(jq -r '.aladdin.repo' "$ALADDIN_CONFIG_FILE"):$(jq -r '.aladdin.tag' "$ALADDIN_CONFIG_FILE")"
-        docker pull "$aladdin_image" ||:
+        docker pull "$aladdin_image"
         echo "$current_time" > "$last_launched_file"
     else
         if "$MANAGE_SOFTWARE_DEPENDENCIES"; then

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -113,7 +113,7 @@ function check_and_handle_init() {
             eval "$repo_login_command"
         fi
         local aladdin_image="$(jq -r '.aladdin.repo' "$ALADDIN_CONFIG_FILE"):$(jq -r '.aladdin.tag' "$ALADDIN_CONFIG_FILE")"
-        docker pull "$aladdin_image"
+        docker pull "$aladdin_image" ||:
         echo "$current_time" > "$last_launched_file"
     else
         if "$MANAGE_SOFTWARE_DEPENDENCIES"; then

--- a/commands/bash/container/bash/bash
+++ b/commands/bash/container/bash/bash
@@ -8,27 +8,24 @@ function run_bash {
         export PS1="$CLUSTER_CODE:$NAMESPACE> "
     fi
     echo "Launching bash shell. Press CTRL+D to exit."
+
     # If authentication is enabled, switch to the AUTHENTICATION_DEFAULT_ROLE level
     if "$AUTHENTICATION_ENABLED"; then
         kubectl config set-context "$NAMESPACE.$CLUSTER_NAME" --cluster "$CLUSTER_NAME" \
             --namespace="$NAMESPACE" --user "$AUTHENTICATION_DEFAULT_ROLE"
     fi
 
-    if [[ "$#" -eq 0 ]]; then
-        bash --init-file "$SCRIPT_DIR/bash_profile.bash"
-    else
-        # --init-file only works for interactive shells and this invocation is not going to
-        # be interactive. Instead, we use the BASH_ENV env var to run our configuration code
-        # prior to the provided command.
-        # https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Invoked-non_002dinteractively
-        BASH_ENV="$SCRIPT_DIR/bash_profile.bash" bash <<<"$@"
-
-        # This an alternative form. Unfortunately, neither of these forms seem to preserve
-        # argument word splitting well. For instance 'echo "hello there"' will be invoked as
-        # 'echo hello there' with two arguments instead of just the intended one.
-        # Suggestions for improvement are welcome.
-        # BASH_ENV="$SCRIPT_DIR/bash_profile.bash" bash -c "$*"
+    # If we received a command, pass it through to the bash invocation with "-c".
+    cmd=( )
+    if [[ "$#" -gt 0 ]]; then
+        cmd=( -c '"$0" "$@"' "$@" )
     fi
+
+    # The BASH_ENV script is only automatically sourced for non-interactive shells, while the --init-file is
+    # only sourced for interactive ones. The "bash_cmd_init.bash" script will source "bash_cmd_includes.bash"
+    # and also perform some extra interactive shell setup.
+    # https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Invoked-non_002dinteractively
+    BASH_ENV="${SCRIPT_DIR}/bash_cmd_includes.bash" bash --init-file "${SCRIPT_DIR}/bash_cmd_init.bash" "${cmd[@]}"
 }
 
 function usage {

--- a/commands/bash/container/bash/bash
+++ b/commands/bash/container/bash/bash
@@ -14,7 +14,6 @@ function run_bash {
             --namespace="$NAMESPACE" --user "$AUTHENTICATION_DEFAULT_ROLE"
     fi
     if [[ -n "$*" ]]; then
-        echo "$@"
         bash --init-file "$SCRIPT_DIR/bash_profile.bash" <<EOF
 $@
 EOF

--- a/commands/bash/container/bash/bash
+++ b/commands/bash/container/bash/bash
@@ -7,13 +7,20 @@ function run_bash {
     else
         export PS1="$CLUSTER_CODE:$NAMESPACE> "
     fi
-    echo Launching bash shell. Press CTRL+D to exit.
+    echo "Launching bash shell. Press CTRL+D to exit."
     # If authentication is enabled, switch to the AUTHENTICATION_DEFAULT_ROLE level
     if "$AUTHENTICATION_ENABLED"; then
         kubectl config set-context "$NAMESPACE.$CLUSTER_NAME" --cluster "$CLUSTER_NAME" \
             --namespace="$NAMESPACE" --user "$AUTHENTICATION_DEFAULT_ROLE"
     fi
-    bash --init-file "$SCRIPT_DIR/bash_profile.bash" "$@"
+    if [[ -n "$*" ]]; then
+        echo "$@"
+        bash --init-file "$SCRIPT_DIR/bash_profile.bash" <<EOF
+$@
+EOF
+    else
+        bash --init-file "$SCRIPT_DIR/bash_profile.bash"
+    fi
 }
 
 function usage {
@@ -25,11 +32,8 @@ function usage {
 	EOF
 }
 
-if [[ $# -eq 0 ]]; then
-    run_bash
-elif [[ "$1" == "-h" || "$1" == "--help" ]]; then
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
     usage
 else
-    echo >&2 "aladdin: error: unrecognized arguments: $1"
-    exit 1
+    run_bash "$@"
 fi

--- a/commands/bash/container/bash/bash
+++ b/commands/bash/container/bash/bash
@@ -18,6 +18,9 @@ function run_bash {
     # If we received a command, pass it through to the bash invocation with "-c".
     cmd=( )
     if [[ "$#" -gt 0 ]]; then
+        # We are passing the literal string '"$0" "$@"'' to bash as the script to run.
+        # The "$0" is necessary for argv alignment, as otherwise it will erroneously
+        # discard the first item in "$@", which is the actual command we wish to run.
         cmd=( -c '"$0" "$@"' "$@" )
     fi
 

--- a/commands/bash/container/bash/bash
+++ b/commands/bash/container/bash/bash
@@ -13,12 +13,15 @@ function run_bash {
         kubectl config set-context "$NAMESPACE.$CLUSTER_NAME" --cluster "$CLUSTER_NAME" \
             --namespace="$NAMESPACE" --user "$AUTHENTICATION_DEFAULT_ROLE"
     fi
-    if [[ -n "$*" ]]; then
-        bash --init-file "$SCRIPT_DIR/bash_profile.bash" <<EOF
-$@
-EOF
-    else
+
+    if [[ "$#" -eq 0 ]]; then
         bash --init-file "$SCRIPT_DIR/bash_profile.bash"
+    else
+        # --init-file only works for interactive shells and since we're supplying stdin
+        # it is not going to be interactive. Instead, we use the BASH_ENV env var to run
+        # our configuration code prior to the provided command.
+        # https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Invoked-non_002dinteractively
+        BASH_ENV="$SCRIPT_DIR/bash_profile.bash" bash <<<"$@"
     fi
 }
 

--- a/commands/bash/container/bash/bash
+++ b/commands/bash/container/bash/bash
@@ -17,11 +17,17 @@ function run_bash {
     if [[ "$#" -eq 0 ]]; then
         bash --init-file "$SCRIPT_DIR/bash_profile.bash"
     else
-        # --init-file only works for interactive shells and since we're supplying stdin
-        # it is not going to be interactive. Instead, we use the BASH_ENV env var to run
-        # our configuration code prior to the provided command.
+        # --init-file only works for interactive shells and this invocation is not going to
+        # be interactive. Instead, we use the BASH_ENV env var to run our configuration code
+        # prior to the provided command.
         # https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Invoked-non_002dinteractively
         BASH_ENV="$SCRIPT_DIR/bash_profile.bash" bash <<<"$@"
+
+        # This an alternative form. Unfortunately, neither of these forms seem to preserve
+        # argument word splitting well. For instance 'echo "hello there"' will be invoked as
+        # 'echo hello there' with two arguments instead of just the intended one.
+        # Suggestions for improvement are welcome.
+        # BASH_ENV="$SCRIPT_DIR/bash_profile.bash" bash -c "$*"
     fi
 }
 

--- a/scripts/bash_cmd_includes.bash
+++ b/scripts/bash_cmd_includes.bash
@@ -3,9 +3,6 @@
 # Bash init script for aladdin.
 # Provide shortcuts functions for a lot of features
 
-echo "This bash contain a lot helpful function aliases to aladdin commands"
-echo "Don't forget to checkout scripts/bash_profile.bash in aladdin"
-
 function change_to_aladdin_permission() {
     echo "Temporarily changing your permissions to run aladdin command..."
     kubectl config set-context "$NAMESPACE.$CLUSTER_NAME" --cluster "$CLUSTER_NAME" \
@@ -51,8 +48,3 @@ for cmd in `ls $ALADDIN_DIR/commands/bash/container/`; do
 done
 
 alias help="$PY_MAIN -h"
-
-source /etc/profile.d/bash_completion.sh
-source <(kubectl completion bash)
-source <(helm completion bash)
-complete -C "$(which aws_completer)" aws

--- a/scripts/bash_cmd_init.bash
+++ b/scripts/bash_cmd_init.bash
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Bash init script for aladdin.
+# Provide shortcuts functions for a lot of features
+
+echo "This bash contain a lot helpful function aliases to aladdin commands."
+echo "See scripts/bash_cmd_includes.bash in aladdin for details."
+
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/bash_cmd_includes.bash"
+
+# Add some shell command completions
+source /etc/profile.d/bash_completion.sh
+source <(kubectl completion bash)
+source <(helm completion bash)
+complete -C "$(which aws_completer)" aws

--- a/scripts/bash_cmd_init.bash
+++ b/scripts/bash_cmd_init.bash
@@ -3,7 +3,7 @@
 # Bash init script for aladdin.
 # Provide shortcuts functions for a lot of features
 
-echo "This bash contain a lot helpful function aliases to aladdin commands."
+echo "This bash shell contain a lot helpful function aliases to aladdin commands."
 echo "See scripts/bash_cmd_includes.bash in aladdin for details."
 
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/bash_cmd_includes.bash"


### PR DESCRIPTION
This allows one to provide a command to `aladdin bash` and have it run directly in the aladdin
container instead of having to wait for the shell prompt and type it in there.

[ALDN-204](https://fivestars.atlassian.net/browse/ALDN-204)