### PR TITLE
[ALDN-205] Use with_aladdin_perms_wrapper for direct aladdin bash commands

### DIFF
--- a/commands/bash/container/bash/bash
+++ b/commands/bash/container/bash/bash
@@ -18,10 +18,11 @@ function run_bash {
     # If we received a command, pass it through to the bash invocation with "-c".
     cmd=( )
     if [[ "$#" -gt 0 ]]; then
-        # We are passing the literal string '"$0" "$@"'' to bash as the script to run.
-        # The "$0" is necessary for argv alignment, as otherwise it will erroneously
-        # discard the first item in "$@", which is the actual command we wish to run.
-        cmd=( -c '"$0" "$@"' "$@" )
+        # We are passing the literal string 'with_aladdin_perms_wrapper "$0" "$@"''
+        # to bash as the script to run. The "$0" is necessary for argv alignment, as
+        # otherwise it will erroneously discard the first item in "$@", which is the
+        # actual command we wish to run.
+        cmd=( -c 'with_aladdin_perms_wrapper "$0" "$@"' "$@" )
     fi
 
     # The BASH_ENV script is only automatically sourced for non-interactive shells, while the --init-file is


### PR DESCRIPTION
The recently-added direct `aladdin bash` command invocation functionality did not provide support
for adopting the intended permissions available to other aladdin commands and tools like `kubectl`.

This wraps the provided command with `with_aladdin_perms_wrapper` when invoking it directly in a
bash shell, thus providing the requisite permissions for the duration of the command.

[ALDN-205](https://fivestars.atlassian.net/browse/ALDN-205)