### PR TITLE
Use helm3 in aladdin commands with fallback helm2 option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,16 +36,16 @@ ARG KUBE_VERSION=1.15.6
 RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/amd64/kubectl && \
     chmod 755 /usr/local/bin/kubectl
 
-ARG HELM_VERSION=2.16.1
-RUN curl -L -o- https://storage.googleapis.com/kubernetes-helm/helm-v$HELM_VERSION-linux-amd64.tar.gz | tar -zxvf - && \
-    cp linux-amd64/helm /usr/local/bin/helm && \
-    chmod 755 /usr/local/bin/helm && \
-    helm init --client-only
+ARG HELM2_VERSION=2.16.1
+RUN curl -L -o- https://storage.googleapis.com/kubernetes-helm/helm-v$HELM2_VERSION-linux-amd64.tar.gz | tar -zxvf - && \
+    cp linux-amd64/helm /usr/local/bin/helm2 && \
+    chmod 755 /usr/local/bin/helm2 && \
+    helm2 init --client-only
 
-ARG HELM3_VERSION=3.3.0
-RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 && \
-    chmod 700 get_helm.sh && \
-    BINARY_NAME=helm3 ./get_helm.sh --version v$HELM3_VERSION
+ARG HELM_VERSION=3.3.4
+RUN curl -L -o- https://get.helm.sh/helm-v$HELM_VERSION-linux-amd64.tar.gz | tar -zxvf - && \
+    cp linux-amd64/helm /usr/local/bin/helm && \
+    chmod 755 /usr/local/bin/helm
 
 ARG KOPS_VERSION=1.15.0
 RUN curl -L -o /usr/local/bin/kops https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION/kops-linux-amd64 && \

--- a/commands/bash/container/delete-namespace/delete-namespace
+++ b/commands/bash/container/delete-namespace/delete-namespace
@@ -2,7 +2,7 @@
 set -eu -o pipefail
 
 function delete_namespace {
-    helm delete --purge $(helm list | awk '{print $1}' | grep -E "\-$1\b")
+    helm delete -n $1 $(helm list --short -n $1)
     kubectl delete namespace $1
 }
 

--- a/commands/python/command/cluster_init.py
+++ b/commands/python/command/cluster_init.py
@@ -18,15 +18,20 @@ def parse_args(sub_parser):
         action="store_true",
         help="don't check if cluster init projects are already installed before installing",
     )
+    subparser.add_argument(
+        "--helm2",
+        action="store_true",
+        help="Use helm2 instead of helm3",
+    )
     subparser.set_defaults(func=cluster_init_args)
 
 
 def cluster_init_args(args):
-    cluster_init(args.force)
+    cluster_init(args.force, args.helm2)
 
 
-def cluster_init(force=False):
-    helm = Helm()
+def cluster_init(force=False, helm2=False):
+    helm = Helm(helm2)
     cr = cluster_rules()
     cluster_init_projects = cr.cluster_init
     for project in cluster_init_projects:

--- a/commands/python/command/deploy.py
+++ b/commands/python/command/deploy.py
@@ -45,6 +45,11 @@ def parse_args(sub_parser):
         help="which git repo to pull from, which should be used if it differs from chart name",
     )
     subparser.add_argument(
+        "--helm2",
+        action="store_true",
+        help="Use helm2 instead of helm3",
+    )
+    subparser.add_argument(
         "--set-override-values",
         default=[],
         nargs="+",
@@ -62,7 +67,8 @@ def deploy_args(args):
         args.force,
         args.force_helm,
         args.repo,
-        args.set_override_values,
+        args.helm2,
+        args.set_override_values
     )
 
 
@@ -75,13 +81,14 @@ def deploy(
     force=False,
     force_helm=False,
     repo=None,
-    set_override_values=None,
+    helm2=False,
+    set_override_values=None
 ):
     if set_override_values is None:
         set_override_values = []
     with tempfile.TemporaryDirectory() as tmpdirname:
         pr = PublishRules()
-        helm = Helm()
+        helm = Helm(helm2)
         cr = cluster_rules(namespace=namespace)
         helm_chart_path = "{}/{}".format(tmpdirname, chart or project)
         hr = HelmRules(cr, chart or project)
@@ -124,7 +131,12 @@ def deploy(
 
         if dry_run:
             helm.dry_run(
-                hr, helm_chart_path, cr.cluster_name, namespace, helm_args=helm_args, **values
+                hr,
+                helm_chart_path,
+                cr.cluster_name,
+                namespace,
+                helm_args=helm_args,
+                **values
             )
         else:
             helm.start(

--- a/commands/python/command/namespace_init.py
+++ b/commands/python/command/namespace_init.py
@@ -19,16 +19,21 @@ def parse_args(sub_parser):
         action="store_true",
         help="don't check if namespace init projects are already installed before installing",
     )
+    subparser.add_argument(
+        "--helm2",
+        action="store_true",
+        help="Use helm2 instead of helm3",
+    )
     add_namespace_argument(subparser)
     subparser.set_defaults(func=namespace_init_args)
 
 
 def namespace_init_args(args):
-    namespace_init(args.namespace, args.force)
+    namespace_init(args.namespace, args.force, args.helm2)
 
 
-def namespace_init(namespace, force=False):
-    helm = Helm()
+def namespace_init(namespace, force=False, helm2=False):
+    helm = Helm(helm2)
     cr = cluster_rules(namespace=namespace)
     namespace_init_projects = cr.namespace_init
     for project in namespace_init_projects:

--- a/commands/python/command/publish.py
+++ b/commands/python/command/publish.py
@@ -56,6 +56,11 @@ def parse_args(sub_parser):
         action="store_true",
         help="recursively initialize and update all submodules included in the project",
     )
+    subparser.add_argument(
+        "--helm2",
+        action="store_true",
+        help="Use helm2 instead of helm3",
+    )
 
     clean_options_groups.add_argument_group(remote_options_group)
 
@@ -64,7 +69,7 @@ def parse_args(sub_parser):
 
 def publish_args(args):
     if args.build_local:
-        publish(args.build_only, args.build_publish_ecr_only, args.publish_helm_only)
+        publish(args.build_only, args.build_publish_ecr_only, args.publish_helm_only, args.helm2)
     else:
         publish_clean(
             args.build_only,
@@ -73,14 +78,15 @@ def publish_args(args):
             args.repo,
             args.git_ref,
             args.init_submodules,
+            args.helm2
         )
 
 
-def publish(build_only, build_publish_ecr_only, publish_helm_only):
+def publish(build_only, build_publish_ecr_only, publish_helm_only, helm2=False):
     pc = ProjectConf()
     pr = PublishRules()
     d = DockerCommands()
-    h = Helm()
+    h = Helm(helm2)
 
     # tags is a list in case we want to add other tags in the future
     tags = [Git.get_hash()]
@@ -106,7 +112,7 @@ def publish(build_only, build_publish_ecr_only, publish_helm_only):
 
 
 def publish_clean(
-    build_only, build_publish_ecr_only, publish_helm_only, repo, git_ref, init_submodules
+    build_only, build_publish_ecr_only, publish_helm_only, repo, git_ref, init_submodules, helm2=False
 ):
     g = Git()
     git_account = load_git_configs()["account"]
@@ -136,4 +142,4 @@ def publish_clean(
                 )
                 return
         with working_directory(tmpdirname):
-            publish(build_only, build_publish_ecr_only, publish_helm_only)
+            publish(build_only, build_publish_ecr_only, publish_helm_only, helm2)

--- a/commands/python/command/rollback.py
+++ b/commands/python/command/rollback.py
@@ -17,19 +17,24 @@ def parse_args(sub_parser):
     subparser.add_argument(
         "--num-versions", type=int, default=1, help="how many versions to rollback, defaults to 1"
     )
+    subparser.add_argument(
+        "--helm2",
+        action="store_true",
+        help="Use helm2 instead of helm3",
+    )
 
 
 def rollback_args(args):
-    rollback(args.project, args.num_versions, args.namespace, args.chart)
+    rollback(args.project, args.num_versions, args.namespace, args.chart, args.helm2)
 
 
-def rollback(project, num_versions, namespace, chart=None):
-    helm = Helm()
+def rollback(project, num_versions, namespace, chart=None, helm2=False):
+    helm = Helm(helm2)
 
     cr = cluster_rules(namespace=namespace)
     hr = HelmRules(cr, chart or project)
 
-    helm.rollback_relative(hr, num_versions)
+    helm.rollback_relative(hr, num_versions, namespace)
 
     sync_ingress.sync_ingress(namespace)
     sync_dns.sync_dns(namespace)

--- a/commands/python/command/start.py
+++ b/commands/python/command/start.py
@@ -37,6 +37,11 @@ def parse_args(sub_parser):
         help="Have helm force resource update through delete/recreate if needed",
     )
     subparser.add_argument(
+        "--helm2",
+        action="store_true",
+        help="Use helm2 instead of helm3",
+    )
+    subparser.add_argument(
         "--set-override-values",
         default=[],
         nargs="+",
@@ -51,6 +56,7 @@ def start_args(args):
         args.dry_run,
         args.with_mount,
         args.force_helm,
+        args.helm2,
         args.set_override_values,
     )
 
@@ -61,12 +67,13 @@ def start(
     dry_run=False,
     with_mount=False,
     force_helm=False,
+    helm2=False,
     set_override_values=None,
 ):
     if set_override_values is None:
         set_override_values = []
     pc = ProjectConf()
-    helm = Helm()
+    helm = Helm(helm2)
 
     cr = cluster_rules(namespace=namespace)
 

--- a/commands/python/command/stop.py
+++ b/commands/python/command/stop.py
@@ -19,15 +19,20 @@ def parse_args(sub_parser):
         dest="charts",
         help="Stop only these charts (may be specified multiple times)",
     )
+    subparser.add_argument(
+        "--helm2",
+        action="store_true",
+        help="Use helm2 instead of helm3",
+    )
 
 
 def stop_args(args):
-    stop(args.namespace, args.charts)
+    stop(args.namespace, args.charts, args.helm2)
 
 
-def stop(namespace, charts):
+def stop(namespace, charts, helm2=False):
     pc = ProjectConf()
-    helm = Helm()
+    helm = Helm(helm2)
 
     cr = cluster_rules(namespace=namespace)
 
@@ -41,7 +46,7 @@ def stop(namespace, charts):
             chart_name = os.path.basename(chart_path)
             if chart_name in charts:
                 hr = HelmRules(cr, chart_name)
-                helm.stop(hr)
+                helm.stop(hr, namespace)
                 sync_required = True
     finally:
         # Sync if any helm.stop() call succeeded, even if a subsequent one failed

--- a/commands/python/command/undeploy.py
+++ b/commands/python/command/undeploy.py
@@ -14,21 +14,27 @@ def parse_args(sub_parser):
     add_namespace_argument(subparser)
     subparser.add_argument("project", help="which project to undeploy")
     subparser.add_argument(
-        "--chart", help="which chart in the project to undeploy, defaults to the project name"
+        "--chart",
+        help="which chart in the project to undeploy, defaults to the project name"
+    )
+    subparser.add_argument(
+        "--helm2",
+        action="store_true",
+        help="Use helm2 instead of helm3",
     )
 
 
 def undeploy_args(args):
-    undeploy(args.project, args.namespace, args.chart)
+    undeploy(args.project, args.namespace, args.chart, args.helm2)
 
 
-def undeploy(project, namespace, chart=None):
-    helm = Helm()
+def undeploy(project, namespace, chart=None, helm2=False):
+    helm = Helm(helm2)
 
     cr = cluster_rules(namespace=namespace)
     hr = HelmRules(cr, chart or project)
 
-    helm.stop(hr)
+    helm.stop(hr, namespace)
 
     sync_ingress.sync_ingress(namespace)
     sync_dns.sync_dns(namespace)

--- a/commands/python/libs/k8s/helm.py
+++ b/commands/python/libs/k8s/helm.py
@@ -14,13 +14,19 @@ class Helm(object):
     PACKAGE_DIR_PATH = "helm_charts/0.0.0/{project_name}/{git_ref}/"
     PACKAGE_PATH = "helm_charts/0.0.0/{project_name}/{git_ref}/{chart_name}.{git_ref}.tgz"
 
+
+    def __init__(self, helm2):
+        self.helm = "helm2" if helm2 else "helm"
+
     @property
     def helm_home(self):
         return join(expanduser("~"), ".helm")
 
     def init(self):
-        # We need to have local helm initialized for it to works
-        subprocess.check_call(["helm", "init", "--client-only"])
+        # Only need to init on helm2. Helm2 Doesn't use tiller and therefore needs no init
+        if self.helm == "helm2":
+            # We need to have local helm2 initialized for helm2 to work
+            subprocess.check_call([self.helm, "init", "--client-only"])
 
     def publish(self, project_name, publish_rules, chart_path, hash):
 
@@ -29,11 +35,18 @@ class Helm(object):
         version = "0.0.0"
 
         logger.info("Building package")
+
         self.init()
 
         charts_dir, chart_name = os.path.split(chart_path)
 
-        subprocess.check_call(["helm", "package", "--version", version, chart_name], cwd=charts_dir)
+        subprocess.check_call([
+            self.helm,
+            "package",
+            "--version",
+            version,
+            chart_name
+        ], cwd=charts_dir)
 
         try:
             package_path = join(charts_dir, "{}-{}.tgz".format(chart_name, version))
@@ -107,12 +120,18 @@ class Helm(object):
 
         return values
 
-    def stop(self, helm_rules):
+    def stop(self, helm_rules, namespace):
         release_name = helm_rules.release_name
 
-        command = ["helm", "delete", "--purge", release_name]
+        command = [self.helm, "delete", release_name]
 
-        if self.release_exists(release_name):
+        # Helm2 needs --purge but not --namespace, whereas helm3 needs --namespace but not --purge
+        if self.helm == "helm2":
+            command.append("--purge")
+        else:
+            command.extend(["--namespace", namespace])
+
+        if self.release_exists(release_name, namespace):
             subprocess.run(command, check=True)
             logger.info("Successfully removed release {}".format(release_name))
         else:
@@ -120,8 +139,13 @@ class Helm(object):
                 "Could not remove release {} because it doesn't exist".format(release_name)
             )
 
-    def release_exists(self, release_name):
-        command = ["helm", "status", release_name]
+    def release_exists(self, release_name, namespace):
+        command = [self.helm, "status", release_name]
+
+        # Helm3 requires --namespace flag, which helm2 doesn't use
+        if self.helm == "helm":
+            command.extend(["--namespace", namespace])
+
         ret_code = subprocess.run(
             command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
         ).returncode
@@ -131,23 +155,36 @@ class Helm(object):
         else:
             return False
 
-    def rollback_relative(self, helm_rules, num_versions):
+    def rollback_relative(self, helm_rules, num_versions, namespace):
         release_name = helm_rules.release_name
 
         # Some ugly logic to get the current revision - probably can be better
-        output = subprocess.Popen(("helm", "list"), stdout=subprocess.PIPE)
+        helm_list_command = [self.helm, "list"]
+        # Helm3 requires --namespace flag, which helm2 doesn't use
+        if self.helm == "helm":
+            helm_list_command.extend(["--namespace", namespace])
+        output = subprocess.Popen(helm_list_command, stdout=subprocess.PIPE)
         output = subprocess.check_output(("grep", release_name), stdin=output.stdout)
-        current_revision = int(output.decode("utf-8").replace(" ", "").split("\t")[1])
+        data = output.decode("utf-8").replace(" ", "").split("\t")
+
+        # For helm2, this is the 2nd column. For helm3 it is the third column
+        if self.helm == "helm2":
+            current_revision = int(data[1])
+        else:
+            current_revision = int(data[2])
 
         if num_versions > current_revision:
             logger.warning("Can't rollback that far")
             return
 
-        self.rollback(helm_rules, current_revision - num_versions)
+        self.rollback(helm_rules, current_revision - num_versions, namespace)
 
-    def rollback(self, helm_rules, revision):
+    def rollback(self, helm_rules, revision, namespace):
         release_name = helm_rules.release_name
-        command = ["helm", "rollback", release_name, str(revision)]
+        command = [self.helm, "rollback", release_name, str(revision)]
+        # Helm3 requires --namespace flag, which helm2 doesn't use
+        if self.helm == "helm":
+            command.extend(["--namespace", namespace])
         subprocess.run(command, check=True)
 
     def start(
@@ -173,7 +210,7 @@ class Helm(object):
         release_name = helm_rules.release_name
 
         command = [
-            "helm",
+            self.helm,
             "upgrade",
             release_name,
             chart_path,

--- a/scripts/infra_k8s_check.sh
+++ b/scripts/infra_k8s_check.sh
@@ -20,7 +20,7 @@ VERSION_DOCKER="18.09.7"
 #- from : https://github.com/kubernetes/kubernetes/releases
 VERSION_KUBECTL="1.15.6"
 #- from : https://github.com/kubernetes/helm/releases
-VERSION_HELM="2.16.1"
+VERSION_HELM="3.3.4"
 FULL_VERSION_VIRTUALBOX="6.0.14r133895"
 
 VERSION_VIRTUALBOX="$(echo "$FULL_VERSION_VIRTUALBOX" | cut -dr -f1)"
@@ -375,21 +375,21 @@ function install_kubectl_ubuntu(){
 }
 
 
-function check_helm(){ version "$ALADDIN_BIN/helm version --client" "Client.*v$VERSION_HELM" ; }
+function check_helm(){ version "$ALADDIN_BIN/helm version" "$VERSION_HELM" ; }
 function install_helm_win(){
-    typeset url="https://storage.googleapis.com/kubernetes-helm/helm-v${VERSION_HELM}-windows-amd64.tar.gz"
-    install_url_tgz "helm.exe" "windows-amd64/helm.exe" "$url"
+    typeset url="https://get.helm.sh/helm-v${VERSION_HELM}-windows-amd64.zip"
+    install_url_zip "helm.exe" "windows-amd64/helm.exe" "$url"
 }
 function install_helm_mac(){
-    typeset url="https://storage.googleapis.com/kubernetes-helm/helm-v${VERSION_HELM}-darwin-amd64.tar.gz"
+    typeset url="https://get.helm.sh/helm-v${VERSION_HELM}-darwin-amd64.tar.gz"
     install_url_tgz "helm" "darwin-amd64/helm" "$url"
 }
 function install_helm_alpine(){
-    typeset url="https://storage.googleapis.com/kubernetes-helm/helm-v${VERSION_HELM}-linux-amd64.tar.gz"
+    typeset url="https://get.helm.sh/helm-v${VERSION_HELM}-linux-amd64.tar.gz"
     install_url_tgz "helm" "linux-amd64/helm" "$url"
 }
 function install_helm_ubuntu(){
-    typeset url="https://storage.googleapis.com/kubernetes-helm/helm-v${VERSION_HELM}-linux-amd64.tar.gz"
+    typeset url="https://get.helm.sh/helm-v${VERSION_HELM}-linux-amd64.tar.gz"
     install_url_tgz "helm" "linux-amd64/helm" "$url"
 }
 


### PR DESCRIPTION
During the helm3 migration, we will have aladdin commands use helm3, but have support for helm2. Once everything has been confirmed to migrate over, we will remove tiller, and remove helm2 support from aladdin.