### PR TITLE
Add ssh to Dockerfile and update installation steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN apt-get update && \
     less \
     openssl \
     vim-nox \
-    curl
+    curl \
+    ssh
 
 RUN pip install --no-cache-dir pip==20.2.3
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The recommended way to install aladdin is using the [install script](./install-a
 
     $ ./install-aladdin
 
+This script will install [pipx](https://github.com/pipxproject/pipx) and then use it to install aladdin in its own virtual environment.
+
 You may also want to add `~/.aladdin/bin` to your path:
 
     $ export PATH=$PATH:~/.aladdin/bin

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ To set up, just clone the Aladdin GitHub repository to get started:
 
 The `infra_k8s_check.sh` script checks to see if all of aladdin's dependencies are installed. Depending on the dependency, it will warn if it is missing or install it in `~/.aladdin/bin` if possible. This script is also run every time you run aladdin.
 
-You may want to add aladdin to your path:
+The recommended way to install aladdin is using the [install script](./install-aladdin):
 
-    $ eval $(./aladdin.sh env)
+    $ ./install-aladdin
 
 You may also want to add `~/.aladdin/bin` to your path:
 
@@ -73,7 +73,7 @@ aladdin uses minikube to get access to docker functionality.
 It also sets up minikube (file sharing etc) so that you can deploy to minikube.
 
 But you may not need that if this applies to your situation:
-1. You already have docker installed (say using docker.app on mac for example) 
+1. You already have docker installed (say using docker.app on mac for example)
 1. You are using an alternative to minikube (like docker-desktop or kind, etc) for local cluster or
 1. You are using aladdin to connect to a remote cluster (like staging, prod etc)
 


### PR DESCRIPTION

This PR updates the "Installation" section of the README. It also adds `ssh` back in, this go inadvertently removed when changing base Docker image and is needed for connecting to github using ssh (for commands like `publish`)