### PR TITLE
Add support for cluster config values

### DIFF
--- a/aladdin/lib/k8s/helm.py
+++ b/aladdin/lib/k8s/helm.py
@@ -115,6 +115,15 @@ class Helm(object):
         if os.path.isfile(cluster_config_values_path):
             logger.info("Found cluster config values file")
             values.append(cluster_config_values_path)
+        cluster_namespace_config_values_path = os.path.join(
+            os.environ["ALADDIN_CONFIG_DIR"],
+            cluster_name,
+            namespace,
+            "values.yaml"
+        )
+        if os.path.isfile(cluster_namespace_config_values_path):
+            logger.info("Found cluster namespace config values file")
+            values.append(cluster_namespace_config_values_path)
 
         return values
 

--- a/aladdin/lib/k8s/helm.py
+++ b/aladdin/lib/k8s/helm.py
@@ -204,11 +204,13 @@ class Helm(object):
         # Values and overrides are defined/specified in helm args in a specific order
         # 1. project values.yaml (picked up by helm automatically)
         # 2. project cluster values.yaml
-        # 3. site.yaml file (on local)
-        # 4. aladdin-config cluster `values.yaml`
-        # 5. aladdin-config cluster namespace `values.yaml`
-        # 6. aladdin-config config.json "values" key
-        # 7. user passed overrides
+        # 3. project cluster namespace values.yaml
+        # 4. site.yaml file (on local)
+        # 5. aladdin-config cluster `values.yaml`
+        # 6. aladdin-config cluster namespace `values.yaml`
+        # 7. aladdin-config cluster config.json "values" key
+        # 8. aladdin-config cluster namespace config.json "values" key
+        # 9. user passed overrides
 
         for path in self.find_values(chart_path, cluster_name, namespace):
             command.append("--values={}".format(path))

--- a/aladdin/lib/k8s/helm.py
+++ b/aladdin/lib/k8s/helm.py
@@ -107,6 +107,15 @@ class Helm(object):
             logger.info("Found site values file")
             values.append(site_values_path)
 
+        cluster_config_values_path = os.path.join(
+            os.environ["ALADDIN_CONFIG_DIR"],
+            cluster_name,
+            "values.yaml"
+        )
+        if os.path.isfile(cluster_config_values_path):
+            logger.info("Found cluster config values file")
+            values.append(cluster_config_values_path)
+
         return values
 
     def stop(self, helm_rules, namespace):

--- a/aladdin/lib/k8s/helm.py
+++ b/aladdin/lib/k8s/helm.py
@@ -90,19 +90,18 @@ class Helm(object):
 
         # Find all possible values yaml files for override in increasing priority
         cluster_values_path = join(chart_path, "values", "values.{}.yaml".format(cluster_name))
-        cluster_namespace_values_path = join(
-            chart_path, "values", "values.{}.{}.yaml".format(cluster_name, namespace)
-        )
-        site_values_path = join(chart_path, "values", "site.yaml")  # Only usable on LOCAL
-
         if os.path.isfile(cluster_values_path):
             logger.info("Found cluster values file")
             values.append(cluster_values_path)
 
+        cluster_namespace_values_path = join(
+            chart_path, "values", "values.{}.{}.yaml".format(cluster_name, namespace)
+        )
         if os.path.isfile(cluster_namespace_values_path):
             logger.info("Found cluster namespace values file")
             values.append(cluster_namespace_values_path)
 
+        site_values_path = join(chart_path, "values", "site.yaml")  # Only usable on LOCAL
         if cluster_name == "LOCAL" and os.path.isfile(site_values_path):
             logger.info("Found site values file")
             values.append(site_values_path)
@@ -115,6 +114,7 @@ class Helm(object):
         if os.path.isfile(cluster_config_values_path):
             logger.info("Found cluster config values file")
             values.append(cluster_config_values_path)
+
         cluster_namespace_config_values_path = os.path.join(
             os.environ["ALADDIN_CONFIG_DIR"],
             cluster_name,
@@ -200,6 +200,15 @@ class Helm(object):
             "--install",
             "--namespace={}".format(namespace),
         ]
+
+        # Values and overrides are defined/specified in helm args in a specific order
+        # 1. project values.yaml (picked up by helm automatically)
+        # 2. project cluster values.yaml
+        # 3. site.yaml file (on local)
+        # 4. aladdin-config cluster `values.yaml`
+        # 5. aladdin-config cluster namespace `values.yaml`
+        # 6. aladdin-config config.json "values" key
+        # 7. user passed overrides
 
         for path in self.find_values(chart_path, cluster_name, namespace):
             command.append("--values={}".format(path))

--- a/docs/create_aladdin_configuration.md
+++ b/docs/create_aladdin_configuration.md
@@ -13,6 +13,7 @@ aladdin-config/
   REMOTE-CLUSTER-1/
     config.json
     env.sh
+    values.yaml     # Optional
   REMOTE-CLUSTER-2/
     config.json
     env.sh
@@ -51,20 +52,20 @@ The config.json file in the root of your config directory will contain non clust
 - Aladdin section:
   - repo: which repo to pull aladdin from. You can change this to your internal repo if you plan on creating a custom aladdin docker image and plan on pushing it there.
   - tag: which tag of the aladdin docker image to pull
-  - repo_login_command: If you plan on extending aladdin, you may need to fill this in with your internal repo's login command 
+  - repo_login_command: If you plan on extending aladdin, you may need to fill this in with your internal repo's login command
 - Cluster Aliases section:
-  - When invoking aladdin, you can pass in the `-c/--cluster` flag to specify a cluster. Here you can add aliases for that cluster option (i.e. specify `-c DEV` rather than `-c CLUSTERDEV` in this example)  
+  - When invoking aladdin, you can pass in the `-c/--cluster` flag to specify a cluster. Here you can add aliases for that cluster option (i.e. specify `-c DEV` rather than `-c CLUSTERDEV` in this example)
 - Git section
-  - account: which git account to pull from. Aladdin mounts your git credentials onto the aladdin container when you call aladdin.  
+  - account: which git account to pull from. Aladdin mounts your git credentials onto the aladdin container when you call aladdin.
 - Kubernetes section:
-  - label: which label to use when filter kubernetes resources. Several aladdin commands use this label to specify which exact resource to modify.  
+  - label: which label to use when filter kubernetes resources. Several aladdin commands use this label to specify which exact resource to modify.
 - Publish section:
   - aws_profile: which aws profile to publish your docker image and helm charts to
   - docker_ecr_repo: the ecr path of your aws profile, used to push your docker images to
   - s3_helm_chart_bucket: which bucket to store your packaged helm charts to
 
 ## Cluster env.sh file
-The env.sh file in each of your subdirectories in your config folder will contain cluster-specific variables that aladdin sources. These variables are mainly used to create your cluster and to get the correct configuration. Here is the example env.sh file from the CLUSTERDEV folder. 
+The env.sh file in each of your subdirectories in your config folder will contain cluster-specific variables that aladdin sources. These variables are mainly used to create your cluster and to get the correct configuration. Here is the example env.sh file from the CLUSTERDEV folder.
 ```bash
 #!/bin/bash
 export CLOUD=aws
@@ -97,7 +98,7 @@ export ADMIN_ACCESS=
 export IMAGE=
 ```
 
-Most these variables are just used by kops when creating the cluster, which is wrapped by aladdin. If you need more info, check [here](https://github.com/kubernetes/kops/blob/master/docs/cli/kops_create_cluster.md). Note that the env.sh in your minikube folder will be mostly empty since you are not actually creating a cluster in that scenario.  
+Most these variables are just used by kops when creating the cluster, which is wrapped by aladdin. If you need more info, check [here](https://github.com/kubernetes/kops/blob/master/docs/cli/kops_create_cluster.md). Note that the env.sh in your minikube folder will be mostly empty since you are not actually creating a cluster in that scenario.
 
 ## Cluster config.json file
 The config.json file in each of your subdirectories in your config folder will contain cluster-specific configuration for your aladdin installation. Here is an example config.json file for a specific cluster:
@@ -125,14 +126,14 @@ The config.json file in each of your subdirectories in your config folder will c
 - aws_profile section: which aws profile you are interacting with for the cluster
 - cluster_name section: the name of your cluster. This will match the name of the subdirectory in most cases.
 - root_dns section: the dns for your cluster. This should match the DNS_ZONE from your env.sh file in most cases. This is used by aladdin when it maps dns for each of your externally accessible services.
-- service_dns_suffix section: aladdin maps your services to `{service name}.{namespace}.{root_dns}`, and thus, will request a certificate for `*.{namespace}.{root_dns}`. By setting this, it will instead request a certificate for `*.{service_dns_suffix}`. Note that you will still need manually to map your service from `{service name}.{service_dns_suffix}` to `{service name}.{namespace}.{root_dns}`. 
- - values section: which values to set for all helm charts in this cluster when running `aladdin deploy` or `aladdin start`
+- service_dns_suffix section: aladdin maps your services to `{service name}.{namespace}.{root_dns}`, and thus, will request a certificate for `*.{namespace}.{root_dns}`. By setting this, it will instead request a certificate for `*.{service_dns_suffix}`. Note that you will still need manually to map your service from `{service name}.{service_dns_suffix}` to `{service name}.{namespace}.{root_dns}`.
+ - values section: which values to set for all helm charts in this cluster when running `aladdin deploy` or `aladdin start`. Additionally you can use a `values.yaml` file in the same directory as your `config.json`.
 - allowed_namespaces section: which namespaces you are allowed to interact with in this cluster
 - check_branch section (not shown in example): which branch on your remote repo to check against before deploying (e.g. set this to master for your production cluster)
 - cluster_init section: which projects to install when running `aladdin cluster init`. You must specify the project, ref, and namespace.
-- namespace_init section (not shown in example): whenever a namespace is created, install any projects in this section. You must specify a project and a ref. 
+- namespace_init section (not shown in example): whenever a namespace is created, install any projects in this section. You must specify a project and a ref.
 - dual_dns_prefix_annotation_name section: you can use this annotation (in this example, it is "dns-name") in your service.yaml files to change the prefix for the dns your service is mapped to
 
-Note: Aladdin also supports a `default/` folder which can have a `config.json` file that other clusters will inherit from. 
+Note: Aladdin also supports a `default/` folder which can have a `config.json` file that other clusters will inherit from.
 
-Note: Aladdin allows you to override configuration on a namespace level as well. To do this, create a namespace-overrides folder in your cluster subdirectory folder, and create a folder for each namespace you want to override config for. Then create a `config.json` file with any overrides. See the `config-example/CLUSTERDEV/namespace-overrides/test/config.json` file for an example. 
+Note: Aladdin allows you to override configuration on a namespace level as well. To do this, create a namespace-overrides folder in your cluster subdirectory folder, and create a folder for each namespace you want to override config for. Then create a `config.json` file with any overrides. See the `config-example/CLUSTERDEV/namespace-overrides/test/config.json` file for an example.


### PR DESCRIPTION

This PR adds support for a `values.yaml` file in `aladdin-config`, it provides the same functionality as the `"values"` key in `config.json`, however a yaml file provides more flexibility in the data types that are supported and how the data is structured.