### PR TITLE
[INFRA-551] - Add Vault flag to utilize Vault secrets

### DIFF
--- a/aladdin.sh
+++ b/aladdin.sh
@@ -316,7 +316,9 @@ function prepare_docker_subcommands() {
     # config maps and other settings can be customized by developers
     MOUNTS_CMD=""
     if "$DEV"; then
-        MOUNTS_CMD="-v $(pathnorm "$ALADDIN_DIR"):/root/aladdin"
+        MOUNTS_CMD="-v $(pathnorm "$ALADDIN_DIR")/aladdin:/root/aladdin/aladdin"
+        MOUNTS_CMD="$MOUNTS_CMD -v $(pathnorm "$ALADDIN_DIR")/scripts:/root/aladdin/scripts"
+        MOUNTS_CMD="$MOUNTS_CMD -v $(pathnorm "$ALADDIN_DIR")/aladdin-container.sh:/root/aladdin/aladdin-container.sh"
     fi
 
     if "$IS_LOCAL"; then

--- a/aladdin/commands/cmd.py
+++ b/aladdin/commands/cmd.py
@@ -15,6 +15,12 @@ def parse_args(sub_parser):
         "app_name", type=str, metavar="app_name", help="app to run commands against"
     )
     subparser.add_argument(
+        "--vault_enabled",
+        help="Loads Vault env to access secrets",
+        default=False,
+        action="store_true"
+    )
+    subparser.add_argument(
         "command_args",
         type=str,
         metavar="comm_args",
@@ -26,11 +32,11 @@ def parse_args(sub_parser):
 
 
 def cmd_args(args):
-    cmd(args.app_name, args.command_args, args.namespace)
+    cmd(args.app_name, args.command_args, args.namespace, args.vault_enabled)
 
 
 @container_command
-def cmd(app_name, command_args, namespace=None):
+def cmd(app_name, command_args, namespace=None, vault_enabled=False):
     k = Kubernetes(namespace=namespace)
     pod_name = k.get_pod_name(f"{app_name}-commands")
 
@@ -42,7 +48,7 @@ def cmd(app_name, command_args, namespace=None):
             k.kub_exec(
                 pod_name,
                 f"{app_name}-commands",
-                "/bin/bash",
+                "/vault/vault-env" if vault_enabled else "/bin/bash",
                 "-c",
                 "command -v aladdin_command",
                 return_output=True,

--- a/aladdin/commands/cmd.py
+++ b/aladdin/commands/cmd.py
@@ -48,7 +48,7 @@ def cmd(app_name, command_args, namespace=None, vault_enabled=False):
             k.kub_exec(
                 pod_name,
                 f"{app_name}-commands",
-                "/vault/vault-env" if vault_enabled else "/bin/bash",
+                "/bin/bash",
                 "-c",
                 "command -v aladdin_command",
                 return_output=True,
@@ -76,4 +76,7 @@ def cmd(app_name, command_args, namespace=None, vault_enabled=False):
             executable = "python"
 
     logging.info("Command output below...")
-    k.kub_exec(pod_name, f"{app_name}-commands", executable, *command_args)
+    if vault_enabled:
+        k.kub_exec(pod_name, f"{app_name}-commands", "/vault/vault-env", "executable, *command_args")
+    else:
+        k.kub_exec(pod_name, f"{app_name}-commands", executable, *command_args)


### PR DESCRIPTION
Aladdin commands weren't pulling secrets from the environment since it was running as a separate process.  I tested the `--vault_enabled` flag locally for reporting service's use case and you can see the secrets being populated with the flag set.  

Without flag:
```
$ aladdin --dev -c KDEV cmd --namespace reporting reporting-service etl -ra True -r True -fd 2019-01-01 -td 2019-02-01
Synchronizing date and time on minikube with the host
.....
END ENVIRONMENT CONFIGURATION===============================================
INFO: Command output below...
GETTING LOGGER FOR commands.packages.helpers.utils
GETTING LOGGER FOR commands.packages.helpers.connectors
GETTING LOGGER FOR commands.packages.recipes.base
GETTING LOGGER FOR commands.packages.recipes.full_restore
GETTING LOGGER FOR commands.packages.validators.base
GETTING LOGGER FOR etl
GETTING LOGGER FOR validate
INFO     etl(102) Running ETL for *transaction*...
EO:: PAPI_DB_USER vault:secret/data/reporting-service#PAPI_DB_USERNAME
EO:: PAPI_DB_PASSWORD vault:secret/data/reporting-service#PAPI_DB_PASSWORD
```

With flag:
```
$ aladdin --dev -c KDEV cmd --namespace reporting --vault_enabled reporting-service etl -ra True -r True -fd 2019-01-01 -td 2019-02-01
Synchronizing date and time on minikube with the host
...
INFO: Command output below...
INFO[0000] received new Vault token                     
INFO[0000] initial Vault token arrived                  
INFO[0000] spawning process: [/usr/local/bin/aladdin_command etl -ra True -r True -fd 2019-01-01 -td 2019-02-01]  app=vault-env
INFO[0000] in daemon mode...                             app=vault-env
INFO[0000] renewed Vault token ttl = 1h0m0s             
INFO[0000] received signal: urgent I/O condition         app=vault-env
GETTING LOGGER FOR commands.packages.helpers.utils
GETTING LOGGER FOR commands.packages.helpers.connectors
GETTING LOGGER FOR commands.packages.recipes.base
GETTING LOGGER FOR commands.packages.recipes.full_restore
GETTING LOGGER FOR commands.packages.validators.base
GETTING LOGGER FOR etl
GETTING LOGGER FOR validate
INFO     etl(102) Running ETL for *transaction*...
EO:: PAPI_DB_USER pay
EO:: PAPI_DB_PASSWORD **********************
```