### PR TITLE
Add version checks and enforcement

### DIFF
--- a/aladdin-container.sh
+++ b/aladdin-container.sh
@@ -10,6 +10,7 @@ SCRIPT_DIR="$ALADDIN_DIR/scripts"
 PY_MAIN="aladdin"
 ALADDIN_PLUGIN_DIR="/root/aladdin-plugins"
 ALADDIN_CONFIG_DIR="/root/aladdin-config"
+ALADDIN_CONTAINER="true"
 
 # Export dirs/paths that are used by plugins/commands
 export ALADDIN_DIR

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -8,7 +8,7 @@ function ctrl_trap(){ exit 1 ; }
 trap ctrl_trap INT
 
 # Set defaults on command line args
-DEV=false
+ALADDIN_DEV=${ALADDIN_DEV:-false}
 INIT=false
 CLUSTER_CODE=minikube
 NAMESPACE=default
@@ -294,7 +294,7 @@ function prepare_docker_subcommands() {
     # if this is not production or staging, we are mounting kubernetes folder so that
     # config maps and other settings can be customized by developers
     MOUNTS_CMD=""
-    if "$DEV"; then
+    if "$ALADDIN_DEV"; then
         MOUNTS_CMD="-v $(pathnorm "$ALADDIN_DIR")/aladdin:/root/aladdin/aladdin"
         MOUNTS_CMD="$MOUNTS_CMD -v $(pathnorm "$ALADDIN_DIR")/scripts:/root/aladdin/scripts"
         MOUNTS_CMD="$MOUNTS_CMD -v $(pathnorm "$ALADDIN_DIR")/aladdin-container.sh:/root/aladdin/aladdin-container.sh"
@@ -310,7 +310,7 @@ function prepare_docker_subcommands() {
         MOUNTS_CMD="$MOUNTS_CMD -v $(pathnorm $ALADDIN_PLUGIN_DIR):/root/aladdin-plugins"
     fi
 
-    if "$DEV" || "$IS_LOCAL"; then
+    if "$ALADDIN_DEV" || "$IS_LOCAL"; then
         MOUNTS_CMD="$MOUNTS_CMD -v /:/aladdin_root"
         MOUNTS_CMD="$MOUNTS_CMD -w /aladdin_root$(pathnorm "$PWD")"
     fi
@@ -349,7 +349,7 @@ function enter_docker_container() {
 
     docker run $FLAGS \
         `# Environment` \
-        -e "DEV=$DEV" \
+        -e "ALADDIN_DEV=$ALADDIN_DEV" \
         -e "INIT=$INIT" \
         -e "CLUSTER_CODE=$CLUSTER_CODE" \
         -e "NAMESPACE=$NAMESPACE" \
@@ -395,7 +395,7 @@ while [[ $# -gt 0 ]]; do
             INIT=true
         ;;
         --dev)
-            DEV=true
+            ALADDIN_DEV=true
         ;;
         --non-terminal)
             IS_TERMINAL=false

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -21,7 +21,7 @@ MANAGE_SOFTWARE_DEPENDENCIES=true
 # Set key directory paths
 ALADDIN_DIR="$(cd "$(dirname "$0")" ; pwd)"
 SCRIPT_DIR="$ALADDIN_DIR/scripts"
-ALADDIN_PLUGIN_DIR=
+ALADDIN_CONFIG_FILE="$ALADDIN_CONFIG_DIR/config.json"
 
 ALADDIN_BIN="$HOME/.aladdin/bin"
 PATH="$ALADDIN_BIN":"$PATH"
@@ -39,27 +39,6 @@ source "$SCRIPT_DIR/shared.sh" # to load _extract_cluster_config_value
 function minikube() {
     if "$MANAGE_MINIKUBE"; then
       command minikube "$@"
-    fi
-}
-function get_config_path() {
-    if [[ ! -f "$HOME/.aladdin/config/config.json" ]]; then
-        echo "Unable to find config directory. Please use 'aladdin config set config_dir <config path location>' to set config directory"
-        exit 1
-    fi
-    ALADDIN_CONFIG_DIR=$(jq -r .config_dir $HOME/.aladdin/config/config.json)
-    if [[ "$ALADDIN_CONFIG_DIR" == null ]]; then
-        echo "Unable to find config directory. Please use 'aladdin config set config_dir <config path location>' to set config directory"
-        exit 1
-    fi
-    ALADDIN_CONFIG_FILE="$ALADDIN_CONFIG_DIR/config.json"
-}
-
-function get_plugin_dir() {
-    if [[ -f "$HOME/.aladdin/config/config.json" ]]; then
-        ALADDIN_PLUGIN_DIR=$(jq -r .plugin_dir $HOME/.aladdin/config/config.json)
-        if [[ "$ALADDIN_PLUGIN_DIR" == null ]]; then
-            ALADDIN_PLUGIN_DIR=
-        fi
     fi
 }
 
@@ -434,8 +413,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 exec_host_command "$@"
-get_config_path
-get_plugin_dir
 get_manage_minikube
 get_manage_software_dependencies
 exec_host_plugin "$@"

--- a/aladdin/config.py
+++ b/aladdin/config.py
@@ -45,7 +45,7 @@ def load_config():
     return load_config_from_file(f'{os.environ["ALADDIN_CONFIG_DIR"]}/config.json')
 
 
-def configure_aladdin_dirs():
+def configure_aladdin_env():
     user_config_path = Path.home() / ".aladdin" / "config" / "config.json"
     error_str = (
         "Unable to find config directory. "

--- a/aladdin/config.py
+++ b/aladdin/config.py
@@ -1,5 +1,9 @@
 import json
+import logging
 import os
+import sys
+
+from pathlib import Path
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
 
@@ -39,3 +43,30 @@ def load_config_from_file(file):
 
 def load_config():
     return load_config_from_file(f'{os.environ["ALADDIN_CONFIG_DIR"]}/config.json')
+
+
+def configure_aladdin_dirs():
+    user_config_path = Path.home() / ".aladdin" / "config" / "config.json"
+    error_str = (
+        "Unable to find config directory. "
+        "Please use 'aladdin config set config_dir <config path location>' "
+        "to set config directory"
+    )
+
+    try:
+        user_config = load_config_from_file(user_config_path)
+    except FileNotFoundError:
+        logging.error(error_str)
+        sys.exit(1)
+
+    try:
+        os.environ["ALADDIN_CONFIG_DIR"] = user_config["config_dir"]
+    except KeyError:
+        logging.error(error_str)
+        sys.exit(1)
+
+    if not os.path.exists(user_config["config_dir"]):
+        logging.error(error_str)
+        sys.exit(1)
+
+    os.environ["ALADDIN_PLUGIN_DIR"] = user_config.get("plugin_dir") or ""

--- a/aladdin/config.py
+++ b/aladdin/config.py
@@ -2,10 +2,12 @@ import json
 import logging
 import os
 import sys
-
+from distutils.util import strtobool
 from pathlib import Path
 
+
 PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
+ALADDIN_DEV = bool(strtobool(os.getenv("ALADDIN_DEV", "false")))
 
 
 def load_cluster_configs():

--- a/aladdin/lib/__init__.py
+++ b/aladdin/lib/__init__.py
@@ -1,0 +1,6 @@
+import os
+from distutils.util import strtobool
+
+
+def in_aladdin_container():
+    return bool(strtobool(os.getenv("ALADDIN_CONTAINER", "false")))

--- a/aladdin/lib/arg_tools.py
+++ b/aladdin/lib/arg_tools.py
@@ -6,6 +6,7 @@ import sys
 import pkg_resources
 
 from aladdin.config import PROJECT_ROOT
+from aladdin.lib import in_aladdin_container
 
 
 def add_namespace_argument(arg_parser):
@@ -33,7 +34,7 @@ def container_command(func=None):
     def _wrapper(*args, **kwargs):
         # using `CLUSTER_CODE` as tell-tale to know
         # if we're "in" the aladdin container
-        if not os.getenv("CLUSTER_CODE"):
+        if not in_aladdin_container():
             return bash_wrapper()
         return func(*args, **kwargs)
     if not func:

--- a/aladdin/lib/git.py
+++ b/aladdin/lib/git.py
@@ -42,7 +42,7 @@ class Git(object):
             # There is no way to check anything
             return value
 
-        ls_remote_res = cls._get_hash_ls_remote(value, git_url)
+        ls_remote_res = cls.get_hash_ls_remote(value, git_url)
         if ls_remote_res:
             return cls._full_hash_to_short_hash(str(ls_remote_res))
 
@@ -50,7 +50,22 @@ class Git(object):
         return cls._full_hash_to_short_hash(value)
 
     @classmethod
-    def _get_hash_ls_remote(cls, ref, url):
+    def get_hash_show_ref(cls, ref):
+        try:
+            output = (
+                subprocess.check_output(
+                    ["git", "show-ref", "--tags", ref],
+                    stderr=subprocess.DEVNULL,
+                    encoding="utf-8"
+                )
+                .split()
+            )
+            return output[0] if output else None
+        except subprocess.CalledProcessError:
+            return None
+
+    @classmethod
+    def get_hash_ls_remote(cls, ref, url, *args):
         """
         This get the info from remote without having to download project/data
         :param ref:
@@ -58,8 +73,11 @@ class Git(object):
         """
         try:
             output = (
-                subprocess.check_output(["git", "ls-remote", url, ref], stderr=subprocess.DEVNULL)
-                .decode("utf-8")
+                subprocess.check_output(
+                    ["git", "ls-remote", url, ref, *args],
+                    stderr=subprocess.DEVNULL,
+                    encoding="utf-8"
+                )
                 .split()
             )
             return output[0] if output else None

--- a/aladdin/lib/version_check.py
+++ b/aladdin/lib/version_check.py
@@ -1,0 +1,50 @@
+import logging
+import os
+import sys
+
+from aladdin import __version__
+from aladdin.lib import in_aladdin_container, utils
+from aladdin.lib.git import Git
+from aladdin.config import load_config, PROJECT_ROOT
+
+
+def check_latest_version():
+    if in_aladdin_container():
+        return
+    config = load_config()
+    repo = config["aladdin"]["repo"]
+    tag = config["aladdin"]["tag"]
+    enforce_version = config["aladdin"].get("enforce_version", False)
+    git_url = f"git@github.com:{repo}.git"
+
+    _aladdin_version_check(tag, git_url, enforce_version=enforce_version)
+    _config_version_check(tag, git_url, enforce_version=enforce_version)
+
+
+def _aladdin_version_check(tag, git_url, enforce_version=False):
+    live = Git.get_hash_ls_remote(tag, git_url, "--tags")
+    current = Git.get_hash_ls_remote(__version__, git_url, "--tags")
+
+    if enforce_version and (not live or not current):
+        return logging.warning("Unable to check for latest aladdin version")
+
+    if live != current:
+        logging.warning("There is a newer version version of aladdin available")
+        if enforce_version:
+            logging.error("Please update aladdin to continue")
+            sys.exit(1)
+
+
+def _config_version_check(tag, git_url, enforce_version=False):
+    with utils.working_directory(os.environ["ALADDIN_CONFIG_DIR"]):
+        current = Git.get_full_hash()
+        live = Git.get_hash_show_ref(tag)
+
+    if enforce_version and (not live or not current):
+        return logging.warning("Unable to check for latest aladdin config version")
+
+    if live != current:
+        logging.warning("There is a newer version version of aladdin config available")
+        if enforce_version:
+            logging.error("Please update aladdin config to continue")
+            sys.exit(1)

--- a/aladdin/lib/version_check.py
+++ b/aladdin/lib/version_check.py
@@ -28,8 +28,10 @@ def _aladdin_version_check(tag, git_url, enforce_version=False):
     live = Git.get_hash_ls_remote(tag, git_url, "--tags")
     current = Git.get_hash_ls_remote(__version__, git_url, "--tags")
 
-    if enforce_version and (not live or not current):
-        return logging.warning("Unable to check for latest aladdin version")
+    if not live or not current:
+        if enforce_version:
+            logging.warning("Unable to check for latest aladdin version")
+        return
 
     if live != current:
         logging.warning("There is a newer version version of aladdin available")
@@ -43,11 +45,32 @@ def _config_version_check(tag, git_url, enforce_version=False):
         current = Git.get_full_hash()
         live = Git.get_hash_show_ref(tag)
 
-    if enforce_version and (not live or not current):
-        return logging.warning("Unable to check for latest aladdin config version")
+    if not live or not current:
+        if enforce_version:
+            logging.warning("Unable to check for latest aladdin config version")
+        return
 
     if live != current:
         logging.warning("There is a newer version version of aladdin config available")
+        if enforce_version:
+            logging.error("Please update aladdin config to continue")
+            sys.exit(1)
+
+
+def _plugins_version_check(tag, git_url, enforce_version=False):
+    if not os.path.exists(os.environ["ALADDIN_PLUGIN_DIR"]):
+        return
+    with utils.working_directory(os.environ["ALADDIN_PLUGIN_DIR"]):
+        current = Git.get_full_hash()
+        live = Git.get_hash_show_ref(tag)
+
+    if not live or not current:
+        if enforce_version:
+            logging.warning("Unable to check for latest aladdin config version")
+        return
+
+    if live != current:
+        logging.warning("There is a newer version version of aladdin plugins available")
         if enforce_version:
             logging.error("Please update aladdin config to continue")
             sys.exit(1)

--- a/aladdin/lib/version_check.py
+++ b/aladdin/lib/version_check.py
@@ -5,7 +5,7 @@ import sys
 from aladdin import __version__
 from aladdin.lib import in_aladdin_container, utils
 from aladdin.lib.git import Git
-from aladdin.config import load_config, PROJECT_ROOT
+from aladdin.config import load_config, ALADDIN_DEV, PROJECT_ROOT
 
 
 def check_latest_version():
@@ -14,7 +14,10 @@ def check_latest_version():
     config = load_config()
     repo = config["aladdin"]["repo"]
     tag = config["aladdin"]["tag"]
-    enforce_version = config["aladdin"].get("enforce_version", False)
+    enforce_version = (
+        config["aladdin"].get("enforce_version", False)
+        and not ALADDIN_DEV
+    )
     git_url = f"git@github.com:{repo}.git"
 
     _aladdin_version_check(tag, git_url, enforce_version=enforce_version)

--- a/aladdin/main.py
+++ b/aladdin/main.py
@@ -1,6 +1,8 @@
 import argparse
 import logging
+import os
 import sys
+from distutils.util import strtobool
 
 import verboselogs
 import coloredlogs
@@ -30,7 +32,7 @@ from aladdin.commands import (
     undeploy,
     version
 )
-from aladdin.config import configure_aladdin_dirs
+from aladdin.config import configure_aladdin_env
 
 
 def cli():
@@ -87,7 +89,10 @@ def cli():
     parser.add_argument("--namespace", "-n", help="The namespace name you want to interact with")
     parser.add_argument("-i", "--init", action="store_true", help="Force initialization logic")
     parser.add_argument(
-        "--dev", action="store_true", help="Mount host's aladdin directory onto aladdin container"
+        "--dev",
+        action="store_true",
+        help="Mount host's aladdin directory onto aladdin container",
+        default=bool(strtobool(os.getenv("ALADDIN_DEV", "false")))
     )
     parser.add_argument("--image", help="Use the specified aladdin image (if building it yourself)")
     parser.add_argument(
@@ -129,7 +134,7 @@ def cli():
     if not sys.argv[1:] or sys.argv[1] in ["-h", "--help"]:
         return parser.print_help()
 
-    configure_aladdin_dirs()
+    configure_aladdin_env()
 
     # if it's not a command we know about it might be a plugin
     # currently the bash scripts handle plugins

--- a/aladdin/main.py
+++ b/aladdin/main.py
@@ -6,6 +6,7 @@ import verboselogs
 import coloredlogs
 
 from aladdin.lib.arg_tools import get_bash_commands, bash_wrapper
+from aladdin.lib.version_check import check_latest_version
 from aladdin.commands import (
     build,
     build_components,
@@ -29,6 +30,7 @@ from aladdin.commands import (
     undeploy,
     version
 )
+from aladdin.config import configure_aladdin_dirs
 
 
 def cli():
@@ -127,6 +129,8 @@ def cli():
     if not sys.argv[1:] or sys.argv[1] in ["-h", "--help"]:
         return parser.print_help()
 
+    configure_aladdin_dirs()
+
     # if it's not a command we know about it might be a plugin
     # currently the bash scripts handle plugins
     cmd_args = list(filter(lambda arg: not arg.startswith("-"), sys.argv[1:]))
@@ -137,4 +141,6 @@ def cli():
         return bash_wrapper()
 
     args = parser.parse_args()
+    if not args.dev:
+        check_latest_version()
     args.func(args)

--- a/aladdin/main.py
+++ b/aladdin/main.py
@@ -1,8 +1,6 @@
 import argparse
 import logging
-import os
 import sys
-from distutils.util import strtobool
 
 import verboselogs
 import coloredlogs
@@ -88,12 +86,6 @@ def cli():
     parser.add_argument("--cluster", "-c", help="The cluster name you want to interact with")
     parser.add_argument("--namespace", "-n", help="The namespace name you want to interact with")
     parser.add_argument("-i", "--init", action="store_true", help="Force initialization logic")
-    parser.add_argument(
-        "--dev",
-        action="store_true",
-        help="Mount host's aladdin directory onto aladdin container",
-        default=bool(strtobool(os.getenv("ALADDIN_DEV", "false")))
-    )
     parser.add_argument("--image", help="Use the specified aladdin image (if building it yourself)")
     parser.add_argument(
         "--skip-prompts",
@@ -146,6 +138,5 @@ def cli():
         return bash_wrapper()
 
     args = parser.parse_args()
-    if not args.dev:
-        check_latest_version()
+    check_latest_version()
     args.func(args)

--- a/aladdin/main.py
+++ b/aladdin/main.py
@@ -127,7 +127,7 @@ def cli():
         return parser.print_help()
 
     configure_aladdin_env()
-
+    check_latest_version()
     # if it's not a command we know about it might be a plugin
     # currently the bash scripts handle plugins
     cmd_args = list(filter(lambda arg: not arg.startswith("-"), sys.argv[1:]))
@@ -138,5 +138,4 @@ def cli():
         return bash_wrapper()
 
     args = parser.parse_args()
-    check_latest_version()
     args.func(args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ include = [
     "aladdin-container.sh",
     "scripts/*",
 ]
+repository = "https://github.com/fivestars-os/aladdin"
+homepage = "https://github.com/fivestars-os/aladdin"
 
 [tool.poetry.dependencies]
 python = "^3.7"


### PR DESCRIPTION
This PR adds a some checks to let the user know when there is a newer version of aladdin, aladdin-config, or aladdin-plugins. All these checks use git to compare hashes of the repo's tags (the tag is already configured in aladdin-config). This PR also adds a new config option "enforce_version" (defaulting to false) which requires that the user is up-to-date in order to execute aladdin commands.