### PR TITLE
Linux NFS mounts: tweaks for compatibility and improved security

### DIFF
--- a/aladdin.sh
+++ b/aladdin.sh
@@ -164,7 +164,8 @@ function _start_minikube() {
             fi
         fi
 
-        bash -c "$minikube_cmd"
+        # If we're using something other than NFS or hosthome, this shouldn't abort the remaining execution.
+        bash -c "$minikube_cmd" || true
     fi
 }
 

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -147,7 +147,7 @@ function _start_minikube() {
         local minikube_cmd="minikube start"
 
         if test "$OSTYPE" = "linux-gnu"; then
-            if test $(minikube config get driver) = "none"; then
+            if [ "$(minikube config get driver)" == "none"]; then
                 # If we're running on native docker on a linux host, minikube start must happen as root
                 # due to limitations in minikube.  Specifying CHANGE_MINIKUBE_NONE_USER causes minikube
                 # to switch users to $SUDO_USER (the user that called sudo) before writing out

--- a/scripts/install_nfs_mounts.sh
+++ b/scripts/install_nfs_mounts.sh
@@ -6,7 +6,16 @@ case "$OSTYPE" in
         mount_dir="/c/Users"
         ;;
     linux*)
-        export_dir="/home"
+        # We should prefer more hardened Linux conventions if we're to use NFS.
+        # In fact, we're better off not using NFS with its security hazards!
+        # - Daniel Rollings
+        if [ -d "/srv/nfs/home" ]; then
+            export_dir="/srv/nfs/home"
+        elif [ -d "/srv/home" ]; then
+            export_dir="/srv/home"
+        else
+            export_dir="/home"
+        fi
         mount_dir="/home"
         ;;
     *)

--- a/scripts/install_nfs_mounts.sh
+++ b/scripts/install_nfs_mounts.sh
@@ -14,6 +14,7 @@ case "$OSTYPE" in
             export_dir="/home"
         fi
         mount_dir="/home"
+        echo "### ALERT: $0 using export_dir ${export_dir}, mount_dir ${mount_dir}"
         ;;
     *)
         export_dir="/Users"
@@ -45,3 +46,4 @@ minikube ssh -- "mount | grep '${mount_dir}'"
 echo -e "\\nTesting directory"
 echo "== ${mount_dir} ================="
 minikube ssh -- "ls -al ${mount_dir}"
+

--- a/scripts/install_nfs_mounts.sh
+++ b/scripts/install_nfs_mounts.sh
@@ -6,9 +6,6 @@ case "$OSTYPE" in
         mount_dir="/c/Users"
         ;;
     linux*)
-        # We should prefer more hardened Linux conventions if we're to use NFS.
-        # In fact, we're better off not using NFS with its security hazards!
-        # - Daniel Rollings
         if [ -d "/srv/nfs/home" ]; then
             export_dir="/srv/nfs/home"
         elif [ -d "/srv/home" ]; then


### PR DESCRIPTION
This PR starts with a small patch to detect and use, in descending order of preference:

/srv/nfs/home
/srv/home
/home

...and mount to /home on the container.

- Daniel Rollings