### PR TITLE
[ALDN-220] Enable ssh agent access in aladdin container

### DIFF
--- a/.githooks/lib/trufflehog-excluded.txt
+++ b/.githooks/lib/trufflehog-excluded.txt
@@ -1,1 +1,2 @@
+commands/bash/container/get-dashboard-url/get-dashboard-url
 aladdin/bash/container/get-dashboard-url/get-dashboard-url

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.egg-info
 .venv
 dist
+.githooks/.collections

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -256,10 +256,10 @@ function prepare_volume_mount_options() {
 function prepare_ssh_options() {
     local ssh_src
 
-    if $(jq -r '.ssh.forward // false' $HOME/.aladdin/config/config.json ); then
+    if $(jq -r '.ssh.agent // false' $HOME/.aladdin/config/config.json ); then
         # Give the container access to the agent socket and tell it where to find it
         if [[ -z ${SSH_AUTH_SOCK:-} ]]; then
-            echo >&2 "Aladdin is configured to use ssh agent forwarding (ssh.forward == true) but SSH_AUTH_SOCK is empty."
+            echo >&2 "Aladdin is configured to use the host's ssh agent (ssh.agent == true) but SSH_AUTH_SOCK is empty."
             exit 1
         fi
         SSH_OPTIONS="-e SSH_AUTH_SOCK=${SSH_AUTH_SOCK} -v ${SSH_AUTH_SOCK}:${SSH_AUTH_SOCK}"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,11 +11,21 @@ If your error is something like this:
 Cloning into '/tmp/tmp7sihubxt'...
 Bad owner or permissions on /root/.ssh/config
 fatal: Could not read from remote repository.
- 
+
 Please make sure you have the correct access rights
 and the repository exists.
-``` 
+```
 try: `chmod 6000 ~/.ssh/config` before rerunning your command
+
+#### Alternative solution: ssh-agent
+If the above does not resolve the issue or causes other issues, you may wish to consider running an [ssh-agent](https://www.ssh.com/academy/ssh/agent) and adding your private keys to that. You can then make the agent available to the aladdin container rather than mounting your `~/.ssh` directory into it.
+
+Once you have the agent running and added your private keys, instruct aladdin to set the `SSH_AUTH_SOCK` environment variable and mount the `SSH_AUTH_SOCK` file as a volume by setting the `ssh.agent` aladdin config value to `true`. This will disable the mounting of the `~/.ssh` directory, as well.
+
+```
+aladdin config set ssh.agent true
+```
+
 ### Error: could not find tiller
 Rerun your aladdin command with `--init` flag to initialize tiller via helm
 ### Error: could not find a ready tiller pod


### PR DESCRIPTION
Mounting the host's `.ssh` directory into the aladdin container at `/root/.ssh` can be problematic
due to ssh's strict requirements regarding file permissions for that directory.

Docker volume mounts set their uid and gid to the host user's uid/gid values. This makes it
difficult for the `root` user to have access to these files without using setuid/setgid tricks, and
in some cases even that is insufficient.

These changes allow a host running an ssh agent with active identities to give the aladdin container
access to the agent by mounting the `SSH_AUTH_SOCK` file. The container's ssh client can then
communicate over the mounted socket, thus eliminating the need to mount the `.ssh` directory into
the container at all.

The behavior will be to default to the `.ssh` directory mount, but utilize the ssh agent socket if the
aladdin config `ssh.agent` is set to `true`.

[ALDN-220](https://jira.fivestars.com/browse/ALDN-220)