### PR TITLE
Add cross-platform image builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,9 @@ jobs:
       - name: Check Out Repo
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -40,6 +43,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Image digest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'cross-platform'
     tags:
       - 'live'
       - '*.*.*'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - 'master'
-      - 'cross-platform'
     tags:
       - 'live'
       - '*.*.*'

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ ARG KUBE_VERSION=1.19.7
 RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/$(dpkg --print-architecture)/kubectl && \
     chmod 755 /usr/local/bin/kubectl
 
-ARG HELM_VERSION=3.6.3
+ARG HELM_VERSION=3.5.2
 RUN curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 -o get-helm-3.sh && \
     chmod 700 get-helm-3.sh && \
     ./get-helm-3.sh --version v${HELM_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN pip install --no-cache-dir pip==20.2.3
 
 # Update all needed tool versions here
 
-ARG AWS_IAM_AUTHENTICATOR_VERSION=1.17.9
+ARG AWS_IAM_AUTHENTICATOR_VERSION=1.21.2
 RUN curl -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/$AWS_IAM_AUTHENTICATOR_VERSION/2020-08-04/bin/linux/$(dpkg --print-architecture)/aws-iam-authenticator && \
     chmod 755 /usr/local/bin/aws-iam-authenticator
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.5-buster as build
+FROM python:3.8.12-buster as build
 
 WORKDIR /root/aladdin
 
@@ -18,7 +18,7 @@ ARG POETRY_VIRTUALENVS_CREATE="false"
 COPY pyproject.toml poetry.lock ./
 RUN poetry install --no-root
 
-FROM python:3.8.5-slim-buster
+FROM python:3.8.12-slim-buster
 
 # Remove the default $PS1 manipulation
 RUN rm /etc/bash.bashrc
@@ -41,7 +41,7 @@ RUN pip install --no-cache-dir pip==20.2.3
 # Update all needed tool versions here
 
 ARG AWS_IAM_AUTHENTICATOR_VERSION=1.17.9
-RUN curl -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/$AWS_IAM_AUTHENTICATOR_VERSION/2020-08-04/bin/linux/amd64/aws-iam-authenticator && \
+RUN curl -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/$AWS_IAM_AUTHENTICATOR_VERSION/2020-08-04/bin/linux/$(dpkg --print-architecture)/aws-iam-authenticator && \
     chmod 755 /usr/local/bin/aws-iam-authenticator
 
 ARG DOCKER_VERSION=20.10.2
@@ -50,16 +50,16 @@ RUN curl -L -o- https://download.docker.com/linux/static/stable/x86_64/docker-$D
     chmod 755 /usr/local/bin/docker
 
 ARG KUBE_VERSION=1.19.7
-RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/amd64/kubectl && \
+RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/$(dpkg --print-architecture)/kubectl && \
     chmod 755 /usr/local/bin/kubectl
 
-ARG HELM_VERSION=3.5.2
-RUN curl -L -o- https://get.helm.sh/helm-v$HELM_VERSION-linux-amd64.tar.gz | tar -zxvf - && \
-    cp linux-amd64/helm /usr/local/bin/helm && \
-    chmod 755 /usr/local/bin/helm
+ARG HELM_VERSION=3.6.3
+RUN curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 -o get-helm-3.sh && \
+    chmod 700 get-helm-3.sh && \
+    ./get-helm-3.sh --version v${HELM_VERSION}
 
 ARG KOPS_VERSION=1.19.1
-RUN curl -Lo kops https://github.com/kubernetes/kops/releases/download/v$KOPS_VERSION/kops-linux-amd64 && \
+RUN curl -Lo kops https://github.com/kubernetes/kops/releases/download/v$KOPS_VERSION/kops-linux-$(dpkg --print-architecture) && \
     chmod +x ./kops && \
     mv ./kops /usr/local/bin/
 
@@ -67,15 +67,8 @@ ARG ISTIO_VERSION=1.9.2
 RUN curl -L https://istio.io/downloadIstio | ISTIO_VERSION="$ISTIO_VERSION" sh - && \
     mv /istio-$ISTIO_VERSION/bin/istioctl /usr/local/bin/istioctl
 
-ARG K3D_VERSION=4.4.4
+ARG K3D_VERSION=4.4.8
 RUN curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v$K3D_VERSION bash
-
-# Install edgectl
-RUN curl -fL https://metriton.datawire.io/downloads/linux/edgectl -o /usr/local/bin/edgectl && \
-    chmod a+x /usr/local/bin/edgectl
-
-# Add datawire helm repo
-RUN helm repo add datawire https://www.getambassador.io
 
 WORKDIR /root/aladdin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN pip install --no-cache-dir pip==20.2.3
 # Update all needed tool versions here
 
 ARG AWS_IAM_AUTHENTICATOR_VERSION=1.21.2
-RUN curl -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/$AWS_IAM_AUTHENTICATOR_VERSION/2020-08-04/bin/linux/$(dpkg --print-architecture)/aws-iam-authenticator && \
+RUN curl -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/$AWS_IAM_AUTHENTICATOR_VERSION/2021-07-05/bin/linux/$(dpkg --print-architecture)/aws-iam-authenticator && \
     chmod 755 /usr/local/bin/aws-iam-authenticator
 
 ARG DOCKER_VERSION=20.10.2

--- a/aladdin/lib/k8s/helm.py
+++ b/aladdin/lib/k8s/helm.py
@@ -18,7 +18,7 @@ class Helm(object):
 
     def publish(self, project_name, publish_rules, chart_path, git_hash):
 
-        version = f"0.0.0-{git_hash}"
+        version = f"0.0.0+{git_hash}"
 
         logger.info("Building package")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aladdin"
-version = "1.19.7.9"
+version = "1.19.7.10"
 description = ""
 authors = ["Fivestars <dev@fivestars.com>"]
 include = [


### PR DESCRIPTION
This adds building an `arm64` flavored image - this means aladdin now has native support for the Mac M1 chipset 🥳 