### PR TITLE
Fix SSH Agent Forwarding for Mac OS

### DIFF
--- a/aladdin.sh
+++ b/aladdin.sh
@@ -270,7 +270,10 @@ function prepare_ssh_options() {
             echo >&2 "Aladdin is configured to use the host's ssh agent (ssh.agent == true) but SSH_AUTH_SOCK is empty."
             exit 1
         fi
-        SSH_OPTIONS="-e SSH_AUTH_SOCK=${SSH_AUTH_SOCK} -v ${SSH_AUTH_SOCK}:${SSH_AUTH_SOCK}"
+        case "$OSTYPE" in
+            darwin*) SSH_OPTIONS="-e SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock" ;;
+            *)       SSH_OPTIONS="-e SSH_AUTH_SOCK=${SSH_AUTH_SOCK} -v ${SSH_AUTH_SOCK}:${SSH_AUTH_SOCK}" ;;
+        esac
     else
         # Default behavior is to attempt to mount the host's .ssh directory into root's home.
         case "$OSTYPE" in

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -271,6 +271,8 @@ function prepare_ssh_options() {
             exit 1
         fi
         case "$OSTYPE" in
+            # docker-desktop on mac only supports this "magic" ssh-agent socket
+            # https://github.com/docker/for-mac/issues/410
             darwin*) SSH_OPTIONS="-e SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock" ;;
             *)       SSH_OPTIONS="-e SSH_AUTH_SOCK=${SSH_AUTH_SOCK} -v ${SSH_AUTH_SOCK}:${SSH_AUTH_SOCK}" ;;
         esac


### PR DESCRIPTION
This PR adds a case statement to set specific `SSH_OPTIONS` for macos