### PR TITLE
Fix aladdin-config path when retrieving values.yaml

### DIFF
--- a/aladdin/lib/k8s/helm.py
+++ b/aladdin/lib/k8s/helm.py
@@ -100,6 +100,8 @@ class Helm(object):
         8. user passed overrides
         """
         values = []
+        # cluster_name could be an alias, "CLUSTER_CODE" is what is used in aladdin-config
+        cluster_code = os.environ["CLUSTER_CODE"]
 
         cluster_values_path = join(chart_path, "values", f"values.{cluster_name}.yaml")
         if os.path.isfile(cluster_values_path):
@@ -129,7 +131,7 @@ class Helm(object):
 
         cluster_config_values_path = os.path.join(
             os.environ["ALADDIN_CONFIG_DIR"],
-            cluster_name,
+            cluster_code,
             "values.yaml"
         )
         if os.path.isfile(cluster_config_values_path):
@@ -138,7 +140,7 @@ class Helm(object):
 
         cluster_namespace_config_values_path = os.path.join(
             os.environ["ALADDIN_CONFIG_DIR"],
-            cluster_name,
+            cluster_code,
             "namespace-overrides",
             namespace,
             "values.yaml"

--- a/docs/create_aladdin_configuration.md
+++ b/docs/create_aladdin_configuration.md
@@ -7,19 +7,22 @@ aladdin-config/
   config.json
   default/
     config.json
+    values.yaml  # Optional
   LOCAL/
     config.json
+    values.yaml
     env.sh
   REMOTE-CLUSTER-1/
     config.json
     env.sh
-    values.yaml     # Optional
+    values.yaml
   REMOTE-CLUSTER-2/
     config.json
     env.sh
     namespace-overrides/
       test/
         config.json
+        values.yaml
 ```
 
 ## Root config.json file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aladdin"
-version = "1.19.7.10"
+version = "1.19.7.11"
 description = ""
 authors = ["Fivestars <dev@fivestars.com>"]
 include = [


### PR DESCRIPTION
This PR fixes a small bug in the helm lib `find_values()` function. The path in aladdin-config should be constructed using the `CLUSTER_CODE` which is guaranteed to be correct.