### PR TITLE
Attach label to namespace, to aid in owner identification

### DIFF
--- a/aladdin-container.sh
+++ b/aladdin-container.sh
@@ -102,7 +102,7 @@ function environment_init() {
         _handle_authentication_config
 
         if $INIT; then
-            kubectl create namespace $NAMESPACE || true
+            $PY_MAIN create-namespace $NAMESPACE
             $PY_MAIN namespace-init --force
         fi
     fi

--- a/aladdin/bash/container/add-aws-assume-role-config/add-aws-assume-role-config
+++ b/aladdin/bash/container/add-aws-assume-role-config/add-aws-assume-role-config
@@ -46,7 +46,7 @@ function add_aws_assume_role_config {
 
 function usage {
     cat <<-EOF
-		usage: aladdin add-aws-assume-role [-h] role profile_name mfa_enabled duration
+		usage: aladdin add-aws-assume-role-config [-h] role profile_name mfa_enabled duration
 
 		positional arguments:
 		  role                  which role to set aws config for

--- a/aladdin/bash/container/add-aws-assume-role-config/add-aws-assume-role-config
+++ b/aladdin/bash/container/add-aws-assume-role-config/add-aws-assume-role-config
@@ -46,7 +46,7 @@ function add_aws_assume_role_config {
 
 function usage {
     cat <<-EOF
-		usage: aladdin aws-assume-role [-h] role profile_name mfa_enabled duration
+		usage: aladdin add-aws-assume-role [-h] role profile_name mfa_enabled duration
 
 		positional arguments:
 		  role                  which role to set aws config for

--- a/aladdin/bash/container/add-aws-assume-role-config/add-aws-assume-role-config
+++ b/aladdin/bash/container/add-aws-assume-role-config/add-aws-assume-role-config
@@ -59,7 +59,7 @@ function usage {
 	EOF
 }
 
-if [[ $# -eq 0 || "$1" == "-h" || "$1" == "--help" ]]; then
+if [[ $# -lt 4 || "$1" == "-h" || "$1" == "--help" ]]; then
     usage
 else
     add_aws_assume_role_config "$@"

--- a/aladdin/bash/container/create-namespace/create-namespace
+++ b/aladdin/bash/container/create-namespace/create-namespace
@@ -3,7 +3,7 @@ set -eu -o pipefail
 
 function create_namespace {
     kubectl create namespace $1
-    kubectl label --overwrite namespace $1 owner=$2
+    kubectl label --overwrite namespace $1 owner=$2 || true
 }
 
 function usage {
@@ -24,7 +24,7 @@ function usage {
 if [[ $# -eq 0 || "$1" == "-h" || "$1" == "--help" ]]; then
     usage
 elif [[ $# -eq 1 ]]; then
-	owner="$(aws sts get-caller-identity --query 'UserId' --output text | awk -F ':' '{print$2}')"
+	owner="$(aws sts get-caller-identity --query 'UserId' --output text | awk -F ':' '{print$2}' || echo nobody)"
     create_namespace $1 $owner
 else
     create_namespace $@

--- a/aladdin/bash/container/create-namespace/create-namespace
+++ b/aladdin/bash/container/create-namespace/create-namespace
@@ -23,8 +23,8 @@ function usage {
 
 if [[ $# -eq 0 || "$1" == "-h" || "$1" == "--help" ]]; then
     usage
-elif [[ $# -eq 1 ]]
-    owner="$(whoami)"  # meaningful on local only
+elif [[ $# -eq 1 ]]; then
+	owner="$(aws sts get-caller-identity --query 'UserId' --output text | awk -F ':' '{print$2}')"
     create_namespace $1 $owner
 else
     create_namespace $@

--- a/aladdin/bash/container/create-namespace/create-namespace
+++ b/aladdin/bash/container/create-namespace/create-namespace
@@ -3,14 +3,18 @@ set -eu -o pipefail
 
 function create_namespace {
     kubectl create namespace $1
+    kubectl label --overwrite namespace $1 owner=$2
 }
 
 function usage {
     cat <<-EOF
-		usage: aladdin create-namespace [-h] namespace
+		usage: aladdin create-namespace [-h] namespace owner
 
 		positional arguments:
 		  namespace             the namespace you want to create
+		  owner                 the owner of the namespace (applied as a label)
+		                        ideally using the format First.Last
+		                        if not supplied then retrieved from `whoami`
           
 		optional arguments:
 		  -h, --help            show this help message and exit
@@ -19,6 +23,9 @@ function usage {
 
 if [[ $# -eq 0 || "$1" == "-h" || "$1" == "--help" ]]; then
     usage
+elif [[ $# -eq 1 ]]
+    owner="$(whoami)"  # meaningful on local only
+    create_namespace $1 $owner
 else
-    create_namespace "$1"
+    create_namespace $@
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aladdin"
-version = "1.19.7.12"
+version = "1.19.7.13"
 description = ""
 authors = ["Fivestars <dev@fivestars.com>"]
 include = [


### PR DESCRIPTION
Extended the `create-namespace` command to slap on a label/tag with the id (from AWS) of the person that created the namespace; this will make it easier when removing potentially orphaned namespaces