### PR TITLE
Add docker-compose to aladdin container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,9 @@ RUN curl -L -o- https://download.docker.com/linux/static/stable/x86_64/docker-$D
     cp docker/docker /usr/local/bin/docker && \
     chmod 755 /usr/local/bin/docker
 
+ARG DOCKER_COMPOSE_VERSION=1.29.2
+RUN curl -L "https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+
 ARG KUBE_VERSION=1.19.7
 RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/$(dpkg --print-architecture)/kubectl && \
     chmod 755 /usr/local/bin/kubectl


### PR DESCRIPTION
This PR adds the [docker-compose](https://docs.docker.com/compose/) CLI to the aladdin container. Although aladdin targets kubernetes specifically `docker-compose` can also be used as a build tool, because of the well-defined `docker-compose.yml` config file users can declaratively define the images that need to be built without the need to define custom scripts for aladdin to execute.

Example:
```yaml
x-common-args: &common-args
  HASH: "${HASH:-local}"

version: '3.8'
services:
  base:
    image: "my-service-base:${HASH:-local}"
    build:
      context: docker
      dockerfile: base.Dockerfile
  api:
    image: "my-service-api:${HASH:-local}"
    build:
      context: .
      dockerfile: docker/api.Dockerfile
      args:
        <<: *common-args
  web:
    image: "my-service-web:${HASH:-local}"
    build:
      context: .
      dockerfile: docker/web.Dockerfile
```

then in `lamp.json` the build command would be:
```jsonc
"name": "my-service",
"build_docker": ["docker-compose", "build"],
// ...
```