### PR TITLE
Use aladdin image matching current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,10 @@ We have several aladdin commands used for development and deployment. Note that 
 - `--skip-prompts` skip any confirmation messages during aladdin execution. Useful when automating commands.
 - `--non-terminal` run aladdin container without tty.
 
-Additionally aladdin checks for a `ALADDIN_DEV=true` environment variable, that when set aladdin will mount the host's aladdin directory onto the aladdin container. This means code changes should be reflected on the container without the need to re-build the image. Mostly useful when developing aladdin.
+Additionally aladdin checks for a `ALADDIN_DEV=true` environment variable that will enable aladdin development options/features such as:
+
+- mounting the host's aladdin directory onto the aladdin container. This means code changes should be reflected on the container without the need to re-build the image. Mostly useful when developing aladdin.
+- specifying an alternate aladdin docker image using the `ALADDIN_IMAGE` environment variable
 
 ## Running several aladdin commands in the same cluster/namespace combo
 Aladdin supports running several commands in the same cluster/namespace combo without having to "reinitialize" aladdin. To do this, go into `aladdin bash`. Then all the container commands will be aliased to be run without prefixing aladdin.

--- a/aladdin.sh
+++ b/aladdin.sh
@@ -15,35 +15,16 @@ NAMESPACE=default
 IS_TERMINAL=true
 SKIP_PROMPTS=false
 KUBERNETES_VERSION="1.19.7"
-MANAGE_SOFTWARE_DEPENDENCIES=true
 
 # Set key directory paths
 ALADDIN_DIR="$(cd "$(dirname "$0")" ; pwd)"
 SCRIPT_DIR="$ALADDIN_DIR/scripts"
-ALADDIN_PLUGIN_DIR=
 
 ALADDIN_BIN="$HOME/.aladdin/bin"
 PATH="$ALADDIN_BIN":"$PATH"
 
 source "$SCRIPT_DIR/shared.sh" # to load _extract_cluster_config_value
 
-function get_plugin_dir() {
-    if [[ -f "$HOME/.aladdin/config/config.json" ]]; then
-        ALADDIN_PLUGIN_DIR=$(jq -r .plugin_dir $HOME/.aladdin/config/config.json)
-        if [[ "$ALADDIN_PLUGIN_DIR" == null ]]; then
-            ALADDIN_PLUGIN_DIR=
-        fi
-    fi
-}
-
-function get_manage_software_dependencies() {
-    if [[ -f "$HOME/.aladdin/config/config.json" ]]; then
-        MANAGE_SOFTWARE_DEPENDENCIES=$(jq -r .manage.software_dependencies $HOME/.aladdin/config/config.json)
-        if [[ "$MANAGE_SOFTWARE_DEPENDENCIES" == null ]]; then
-            MANAGE_SOFTWARE_DEPENDENCIES=true
-        fi
-    fi
-}
 # Check for cluster name aliases and alias them accordingly
 function check_cluster_alias() {
     cluster_alias=$(jq -r --arg key "$CLUSTER_CODE" '.cluster_aliases[$key]' "$ALADDIN_CONFIG_DIR/config.json")
@@ -98,27 +79,23 @@ function check_and_handle_init() {
     if [[ "$current_time" -gt "$((${previous_run:-0}+init_every))" || "$previous_run" -gt "$current_time" ]]; then
         INIT=true
     fi
-    # Handle initialization logic
-    if "$INIT"; then
-        if "$MANAGE_SOFTWARE_DEPENDENCIES"; then
-            "$SCRIPT_DIR"/infra_k8s_check.sh --force
-        fi
-        check_or_start_k3d
+    if ! docker image inspect $ALADDIN_IMAGE &> /dev/null; then
         readonly repo_login_command="$(jq -r '.aladdin.repo_login_command' "$ALADDIN_CONFIG_DIR/config.json")"
         if [[ "$repo_login_command" != "null" ]]; then
             eval "$repo_login_command"
         fi
-        local aladdin_image="$(jq -r '.aladdin.repo' "$ALADDIN_CONFIG_DIR/config.json"):$(jq -r '.aladdin.tag' "$ALADDIN_CONFIG_DIR/config.json")"
-        if [[ $aladdin_image == *"/"* ]]; then
-            docker pull "$aladdin_image"
-        fi
-        echo "$current_time" > "$last_launched_file"
-    else
-        if "$MANAGE_SOFTWARE_DEPENDENCIES"; then
-            "$SCRIPT_DIR"/infra_k8s_check.sh
-        fi
-        check_or_start_k3d
+        docker pull "$ALADDIN_IMAGE"
     fi
+    # Handle initialization logic
+    local infra_k8s_check_args=""
+    if "$INIT"; then
+        infra_k8s_check_args="--force"
+        echo "$current_time" > "$last_launched_file"
+    fi
+    if "$ALADDIN_MANAGE_SOFTWARE_DEPENDENCIES"; then
+        "$SCRIPT_DIR"/infra_k8s_check.sh $infra_k8s_check_args
+    fi
+    check_or_start_k3d
 }
 
 function _start_k3d() {
@@ -284,8 +261,6 @@ function enter_docker_container() {
         FLAGS+="t"
     fi
 
-    local aladdin_image="${IMAGE:-"$(jq -r '.aladdin.repo' "$ALADDIN_CONFIG_DIR/config.json"):$(jq -r '.aladdin.tag' "$ALADDIN_CONFIG_DIR/config.json")"}"
-
     docker run $FLAGS \
         `# Environment` \
         -e "ALADDIN_DEV=$ALADDIN_DEV" \
@@ -309,7 +284,7 @@ function enter_docker_container() {
         -v /var/run/docker.sock:/var/run/docker.sock \
         ${VOLUME_MOUNTS_OPTIONS} \
         ${SSH_OPTIONS} \
-        "$aladdin_image" \
+        "$ALADDIN_IMAGE" \
         `# Finally, launch the command` \
         /root/aladdin/aladdin-container.sh "$@"
 }
@@ -323,10 +298,6 @@ while [[ $# -gt 0 ]]; do
         ;;
         -n|--namespace)
             NAMESPACE="$2"
-            shift # past argument
-        ;;
-        --image)
-            IMAGE="$2"
             shift # past argument
         ;;
         -i|--init)
@@ -348,9 +319,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 exec_host_command "$@"
-get_plugin_dir
 get_host_addr
-get_manage_software_dependencies
 exec_host_plugin "$@"
 check_cluster_alias
 get_config_variables

--- a/aladdin/config.py
+++ b/aladdin/config.py
@@ -1,17 +1,16 @@
 import json
 import os
 import pathlib
-import subprocess
 from distutils.util import strtobool
 
 from aladdin import __version__
 from aladdin.lib import logging
-from aladdin.lib.utils import working_directory
 
 logger = logging.getLogger(__name__)
 
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
+ALADDIN_DOCKER_REPO = "fivestarsos/aladdin"
 
 
 def load_cluster_configs():
@@ -51,7 +50,7 @@ def load_config():
     return load_config_from_file(f'{os.environ["ALADDIN_CONFIG_DIR"]}/config.json')
 
 
-def load_user_config_file() -> dict:
+def load_user_config() -> dict:
     home = pathlib.Path.home()
     return load_config_from_file(home / ".aladdin/config/config.json")
 
@@ -62,91 +61,4 @@ def set_user_config_file(config: dict):
         json.dump(config, json_file, indent=2)
 
 
-def set_config_path() -> bool:
-    """
-    Function to set the "ALADDIN_CONFIG_DIR" env var
-    Uses git to fetch the latest revision of the config repo
-
-    NOTE:
-    If this function returns False it will short-circuit execution of
-    any aladdin command, so returning False should be preceded by some
-    user-friendly error statement about why we're exiting
-    """
-    if os.getenv("ALADDIN_CONFIG_DIR"):
-        # Aladdin config is already set, nothing to do here
-        return True
-
-    err_message = (
-        "Unable to find config repo. "
-        "Please use "
-        "'aladdin config set config_repo <git@github.com:{git_account}/{repo}.git>' "
-        "to set config repo"
-    )
-    try:
-        config = load_user_config_file()
-    except FileNotFoundError:
-        logger.error(err_message)
-        return False
-
-    config_dir: str = config.get("config_dir")
-    config_repo: str = config.get("config_repo")
-    if not config_dir and not config_repo:
-        logger.error(err_message)
-        return False
-
-    if not config_repo:
-        # try to auto-set config_repo
-        if not os.path.isdir(config_dir):
-            logger.error(err_message)
-            return False
-        with working_directory(config_dir):
-            try:
-                remote = subprocess.run(
-                    "git remote get-url origin".split(),
-                    check=True,
-                    capture_output=True,
-                    encoding="utf-8"
-                ).stdout.strip()
-            except subprocess.CalledProcessError:
-                logger.error(err_message)
-                return False
-        *_, git_account, repo = remote.split("/")
-        config_repo = f"git@github.com:{git_account}/{repo}"
-        config["config_repo"] = config_repo
-        set_user_config_file(config)
-
-    remote_config_path = pathlib.Path.home() / ".aladdin/remote_config"
-    commands = [f"git clone -b {__version__} {config_repo} remote_config"]
-    cwd = pathlib.Path.home() / ".aladdin"
-    if os.path.isdir(remote_config_path) and os.path.isdir(remote_config_path / ".git"):
-        cwd = remote_config_path
-        commands = [
-            "git fetch --tags --prune -f",
-            f"git checkout {__version__}"
-        ]
-    with working_directory(cwd):
-        for command in commands:
-            try:
-                subprocess.run(
-                    command.split(),
-                    check=True,
-                    encoding="utf-8",
-                    capture_output=True
-                )
-            except subprocess.CalledProcessError as e:
-                logger.error(
-                    "Failed to fetch aladdin config (%s) from remote: \n%s",
-                    config_repo,
-                    e.stderr.strip() or e.stdout.strip()
-                )
-                return False
-
-    os.environ["ALADDIN_CONFIG_DIR"] = str(remote_config_path)
-
-    if strtobool(os.getenv("ALADDIN_DEV", "false")) and config_dir and os.path.isdir(config_dir):
-        """
-        Allow aladdin developers to use a custom config
-        """
-        os.environ["ALADDIN_CONFIG_DIR"] = config_dir
-
-    return True
+ALADDIN_DEV = bool(strtobool(os.getenv("ALADDIN_DEV", "false")))

--- a/aladdin/env.py
+++ b/aladdin/env.py
@@ -1,0 +1,116 @@
+import os
+import os
+import pathlib
+import subprocess
+
+from jmespath import search
+
+from aladdin import __version__, config
+from aladdin.lib import logging
+from aladdin.lib.utils import working_directory
+
+logger = logging.getLogger(__name__)
+
+
+def configure_env():
+    os.environ["ALADDIN_PLUGIN_DIR"] = config.load_user_config().get("plugin_dir") or ""
+    manage_software_dependencies = search("manage.software_dependencies", config.load_user_config())
+    os.environ["ALADDIN_MANAGE_SOFTWARE_DEPENDENCIES"] = (
+        # default of True if not specified
+        True if manage_software_dependencies is None else manage_software_dependencies
+    )
+    if not os.getenv("ALADDIN_IMAGE") or not config.ALADDIN_DEV:
+        os.environ["ALADDIN_IMAGE"] = "{}:{}".format(
+            search("aladdin.repo", config.load_config()) or config.ALADDIN_DOCKER_REPO,
+            __version__
+        )
+
+
+def set_config_path() -> bool:
+    """
+    Function to set the "ALADDIN_CONFIG_DIR" env var
+    Uses git to fetch the latest revision of the config repo
+
+    NOTE:
+    If this function returns False it will short-circuit execution of
+    any aladdin command, so returning False should be preceded by some
+    user-friendly error statement about why we're exiting
+    """
+    if os.getenv("ALADDIN_CONFIG_DIR"):
+        # Aladdin config is already set, nothing to do here
+        return True
+
+    err_message = (
+        "Unable to find config repo. "
+        "Please use "
+        "'aladdin config set config_repo <git@github.com:{git_account}/{repo}.git>' "
+        "to set config repo"
+    )
+    try:
+        user_config = config.load_user_config()
+    except FileNotFoundError:
+        logger.error(err_message)
+        return False
+
+    config_dir: str = user_config.get("config_dir")
+    config_repo: str = user_config.get("config_repo")
+    if not config_dir and not config_repo:
+        logger.error(err_message)
+        return False
+
+    if not config_repo:
+        # try to auto-set config_repo
+        if not os.path.isdir(config_dir):
+            logger.error(err_message)
+            return False
+        with working_directory(config_dir):
+            try:
+                remote = subprocess.run(
+                    "git remote get-url origin".split(),
+                    check=True,
+                    capture_output=True,
+                    encoding="utf-8"
+                ).stdout.strip()
+            except subprocess.CalledProcessError:
+                logger.error(err_message)
+                return False
+        *_, git_account, repo = remote.split("/")
+        config_repo = f"git@github.com:{git_account}/{repo}"
+        user_config["config_repo"] = config_repo
+        config.set_user_config_file(user_config)
+
+    remote_config_path = pathlib.Path.home() / ".aladdin/remote_config"
+    commands = [f"git clone -b {__version__} {config_repo} remote_config"]
+    cwd = pathlib.Path.home() / ".aladdin"
+    if os.path.isdir(remote_config_path) and os.path.isdir(remote_config_path / ".git"):
+        cwd = remote_config_path
+        commands = [
+            "git fetch --tags --prune -f",
+            f"git checkout {__version__}"
+        ]
+    with working_directory(cwd):
+        for command in commands:
+            try:
+                subprocess.run(
+                    command.split(),
+                    check=True,
+                    encoding="utf-8",
+                    capture_output=True
+                )
+            except subprocess.CalledProcessError as e:
+                logger.error(
+                    "Failed to fetch aladdin config (%s) from remote: \n%s",
+                    config_repo,
+                    e.stderr.strip() or e.stdout.strip()
+                )
+                return False
+
+    os.environ["ALADDIN_CONFIG_DIR"] = str(remote_config_path)
+
+    if config.ALADDIN_DEV and config_dir and os.path.isdir(config_dir):
+        """
+        Allow aladdin developers to use a custom config
+        """
+        os.environ["ALADDIN_CONFIG_DIR"] = config_dir
+
+    return True

--- a/aladdin/env.py
+++ b/aladdin/env.py
@@ -5,6 +5,7 @@ import os
 import os
 import pathlib
 import subprocess
+from typing import Optional
 
 from jmespath import search
 
@@ -16,11 +17,14 @@ logger = logging.getLogger(__name__)
 
 def configure_env():
     os.environ["ALADDIN_PLUGIN_DIR"] = config.load_user_config().get("plugin_dir") or ""
-    manage_software_dependencies = search("manage.software_dependencies", config.load_user_config())
-    os.environ["ALADDIN_MANAGE_SOFTWARE_DEPENDENCIES"] = (
+    manage_software_dependencies: Optional[bool] = search(
+        "manage.software_dependencies",
+        config.load_user_config()
+    )
+    os.environ["ALADDIN_MANAGE_SOFTWARE_DEPENDENCIES"] = str(
         # default of True if not specified
         True if manage_software_dependencies is None else manage_software_dependencies
-    )
+    ).lower()
 
     # Allow aladdin devs to use a custom aladdin image by setting ALADDIN_IMAGE
     if not (os.getenv("ALADDIN_IMAGE") and config.ALADDIN_DEV):

--- a/aladdin/env.py
+++ b/aladdin/env.py
@@ -1,3 +1,6 @@
+"""
+Module to configure environment variables used by Aladdin
+"""
 import os
 import os
 import pathlib
@@ -7,7 +10,6 @@ from jmespath import search
 
 from aladdin import __version__, config
 from aladdin.lib import logging
-from aladdin.lib.utils import working_directory
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +21,11 @@ def configure_env():
         # default of True if not specified
         True if manage_software_dependencies is None else manage_software_dependencies
     )
-    if not os.getenv("ALADDIN_IMAGE") or not config.ALADDIN_DEV:
+
+    # Allow aladdin devs to use a custom aladdin image by setting ALADDIN_IMAGE
+    if not (os.getenv("ALADDIN_IMAGE") and config.ALADDIN_DEV):
+        # Set ALADDIN_IMAGE from the "aladdin.repo" config (or config.ALADDIN_DOCKER_REPO) and
+        # use the aladdin version as the image tag
         os.environ["ALADDIN_IMAGE"] = "{}:{}".format(
             search("aladdin.repo", config.load_config()) or config.ALADDIN_DOCKER_REPO,
             __version__
@@ -29,7 +35,8 @@ def configure_env():
 def set_config_path() -> bool:
     """
     Function to set the "ALADDIN_CONFIG_DIR" env var
-    Uses git to fetch the latest revision of the config repo
+    Uses git to fetch the latest revision of the config repo, the repo
+    is expected to have a branch or tag that matches the current aladdin version
 
     NOTE:
     If this function returns False it will short-circuit execution of
@@ -59,51 +66,62 @@ def set_config_path() -> bool:
         return False
 
     if not config_repo:
-        # try to auto-set config_repo
+        """
+        Some users might only have "config_dir" setup because
+        "config_repo" was introduced in v1.19.7.14
+
+        This code path makes the version upgrade smooth by automatically setting
+        "config_repo" from "config_dir"
+        """
         if not os.path.isdir(config_dir):
             logger.error(err_message)
             return False
-        with working_directory(config_dir):
-            try:
-                remote = subprocess.run(
-                    "git remote get-url origin".split(),
-                    check=True,
-                    capture_output=True,
-                    encoding="utf-8"
-                ).stdout.strip()
-            except subprocess.CalledProcessError:
-                logger.error(err_message)
-                return False
+        try:
+            remote = subprocess.run(
+                "git remote get-url origin".split(),
+                check=True,
+                capture_output=True,
+                encoding="utf-8",
+                cwd=config_dir,
+            ).stdout.strip()
+        except subprocess.CalledProcessError:
+            logger.error(err_message)
+            return False
         *_, git_account, repo = remote.split("/")
         config_repo = f"git@github.com:{git_account}/{repo}"
         user_config["config_repo"] = config_repo
         config.set_user_config_file(user_config)
 
-    remote_config_path = pathlib.Path.home() / ".aladdin/remote_config"
-    commands = [f"git clone -b {__version__} {config_repo} remote_config"]
+    # The config repo is expected to have a branch or tag matching the current aladdin version
+    git_commands = [f"git clone -b {__version__} {config_repo} remote_config"]
     cwd = pathlib.Path.home() / ".aladdin"
+    remote_config_path = cwd / "remote_config"
     if os.path.isdir(remote_config_path) and os.path.isdir(remote_config_path / ".git"):
+        """
+        The remote config has already been checked out,
+        we update git tags and checkout the latest revision
+        """
         cwd = remote_config_path
-        commands = [
+        git_commands = [
             "git fetch --tags --prune -f",
             f"git checkout {__version__}"
         ]
-    with working_directory(cwd):
-        for command in commands:
-            try:
-                subprocess.run(
-                    command.split(),
-                    check=True,
-                    encoding="utf-8",
-                    capture_output=True
-                )
-            except subprocess.CalledProcessError as e:
-                logger.error(
-                    "Failed to fetch aladdin config (%s) from remote: \n%s",
-                    config_repo,
-                    e.stderr.strip() or e.stdout.strip()
-                )
-                return False
+    for command in git_commands:
+        try:
+            subprocess.run(
+                command.split(),
+                check=True,
+                encoding="utf-8",
+                capture_output=True,
+                cwd=str(cwd),
+            )
+        except subprocess.CalledProcessError as e:
+            logger.error(
+                "Failed to fetch aladdin config (%s) from remote: \n%s",
+                config_repo,
+                e.stderr.strip() or e.stdout.strip()
+            )
+            return False
 
     os.environ["ALADDIN_CONFIG_DIR"] = str(remote_config_path)
 

--- a/aladdin/env.py
+++ b/aladdin/env.py
@@ -100,7 +100,7 @@ def set_repo_path(env_key: str, dir_key: str, repo_key: str, required: bool = Fa
             return False
         *_, git_account, repo = remote.split("/")
         repo_value = f"git@github.com:{git_account}/{repo}"
-        user_config["repo_value"] = repo_value
+        user_config[repo_key] = repo_value
         config.set_user_config_file(user_config)
 
     # The config repo is expected to have a branch or tag matching the current aladdin version

--- a/aladdin/main.py
+++ b/aladdin/main.py
@@ -5,7 +5,7 @@ import sys
 import verboselogs
 import coloredlogs
 
-from aladdin import config
+from aladdin import env
 from aladdin.lib.arg_tools import get_bash_commands, bash_wrapper
 from aladdin.commands import (
     build,
@@ -125,8 +125,9 @@ def cli():
     if not sys.argv[1:] or sys.argv[1] in ["-h", "--help"]:
         return parser.print_help()
 
-    if not config.set_config_path():
+    if not env.set_config_path():
         return sys.exit(1)
+    env.configure_env()
 
     # if it's not a command we know about it might be a plugin
     # currently the bash scripts handle plugins

--- a/config-example/config.json
+++ b/config-example/config.json
@@ -1,7 +1,6 @@
 {
     "aladdin": {
-      "repo": "fivestarsos/aladdin",
-      "tag": "1.0.0"
+      "repo": "fivestarsos/aladdin"
     },
     "cluster_aliases": {
         "DEV": "CLUSTERDEV",

--- a/docs/create_aladdin_configuration.md
+++ b/docs/create_aladdin_configuration.md
@@ -31,8 +31,7 @@ The config.json file in the root of your config directory will contain non clust
 ```
 {
     "aladdin": {
-      "repo": "fivestarsos/aladdin",
-      "tag": "1.0.0"
+      "repo": "fivestarsos/aladdin"
     },
     "cluster_aliases": {
         "DEV": "CLUSTERDEV",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aladdin"
-version = "1.19.7.14"
+version = "1.19.7.15"
 description = ""
 authors = ["Fivestars <dev@fivestars.com>"]
 include = [


### PR DESCRIPTION
This PR updates aladdin to use the current package version to pull the corresponding docker image. This ensures that the host code and the container code are always in sync, otherwise there could be breaking changes between the two.