### PR TITLE
Make namespace creation declarative

### DIFF
--- a/aladdin/bash/container/cluster/cluster
+++ b/aladdin/bash/container/cluster/cluster
@@ -162,7 +162,7 @@ function populate {
     sleep 1
     for ns in $(cat "$path_to_resources/namespaces.txt")
     do
-        kubectl create namespace "$ns" || true
+        kubectl create namespace "$ns" --dry-run=client -o yaml | kubectl apply -f -
         kubectl apply -f "$path_to_resources/$ns.yaml" || true
     done
 

--- a/aladdin/bash/container/create-namespace/create-namespace
+++ b/aladdin/bash/container/create-namespace/create-namespace
@@ -2,7 +2,7 @@
 set -eu -o pipefail
 
 function create_namespace {
-    kubectl create namespace $1
+    kubectl create namespace $1 --dry-run=client -o yaml | kubectl apply -f -
     kubectl label --overwrite namespace $1 owner=$2 || true
 }
 


### PR DESCRIPTION
1. Fix the permanent error from aladdin:
`Error from server (AlreadyExists): namespaces "default" already exists`
2. Keep aladdin output dry