### PR TITLE
Update kOps to 1.21.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-he
     chmod 700 get-helm-3.sh && \
     ./get-helm-3.sh --version v${HELM_VERSION}
 
-ARG KOPS_VERSION=1.19.1
+ARG KOPS_VERSION=1.21.1
 RUN curl -Lo kops https://github.com/kubernetes/kops/releases/download/v$KOPS_VERSION/kops-linux-$(dpkg --print-architecture) && \
     chmod +x ./kops && \
     mv ./kops /usr/local/bin/

--- a/aladdin/env.py
+++ b/aladdin/env.py
@@ -5,6 +5,7 @@ import os
 import os
 import pathlib
 import subprocess
+from contextlib import suppress
 from typing import Optional
 
 from jmespath import search
@@ -17,10 +18,10 @@ logger = logging.getLogger(__name__)
 
 def configure_env():
     set_repo_path("ALADDIN_PLUGIN_DIR", "plugin_dir", "plugin_repo", required=False)
-    manage_software_dependencies: Optional[bool] = search(
-        "manage.software_dependencies",
-        config.load_user_config()
-    )
+    user_config = {}
+    with suppress(FileNotFoundError):
+        user_config = config.load_user_config()
+    manage_software_dependencies: Optional[bool] = search("manage.software_dependencies", user_config)
     os.environ["ALADDIN_MANAGE_SOFTWARE_DEPENDENCIES"] = str(
         # default of True if not specified
         True if manage_software_dependencies is None else manage_software_dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aladdin"
-version = "1.19.7.16"
+version = "1.19.7.17"
 description = ""
 authors = ["Fivestars <dev@fivestars.com>"]
 include = [


### PR DESCRIPTION
This PR updates kOps version to 1.21.1

Additionally it fixes a `FileNotFoundError` error when loading the aladdin user config