### PR TITLE
Avoid duplicate repo prefix

### DIFF
--- a/aladdin-container.sh
+++ b/aladdin-container.sh
@@ -102,7 +102,7 @@ function environment_init() {
         _handle_authentication_config
 
         if $INIT; then
-            $PY_MAIN create-namespace $NAMESPACE || true
+            $ALADDIN_DIR/aladdin/bash/container/create-namespace/create-namespace $NAMESPACE || true
             $PY_MAIN namespace-init --force
         fi
     fi

--- a/aladdin/env.py
+++ b/aladdin/env.py
@@ -90,7 +90,7 @@ def set_repo_path(env_key: str, dir_key: str, repo_key: str, required: bool = Fa
             return False
         try:
             remote = subprocess.run(
-                "git remote get-url origin".split(),
+                "git config --get remote.origin.url".split(),
                 check=True,
                 capture_output=True,
                 encoding="utf-8",
@@ -100,7 +100,9 @@ def set_repo_path(env_key: str, dir_key: str, repo_key: str, required: bool = Fa
             logger.error(err_message)
             return False
         *_, git_account, repo = remote.split("/")
-        repo_value = f"git@github.com:{git_account}/{repo}"
+        repo_value = f"{git_account}/{repo}"
+        if not repo_value.startswith("git@github.com:"):
+            repo_value = f"git@github.com:{repo_value}"
         user_config[repo_key] = repo_value
         config.set_user_config_file(user_config)
 

--- a/aladdin/lib/k8s/kubernetes.py
+++ b/aladdin/lib/k8s/kubernetes.py
@@ -33,7 +33,7 @@ class Kubernetes(object):
         self.kubeconfig = kubeconfig or os.getenv("KUBECONFIG")
         try:
             config.load_kube_config(self.kubeconfig)
-        except IOError:
+        except Exception:
             try:
                 config.load_incluster_config()  # How to set up the client from within a k8s pod
             except config.config_exception.ConfigException:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aladdin"
-version = "1.19.7.17"
+version = "1.19.7.18"
 description = ""
 authors = ["Fivestars <dev@fivestars.com>"]
 include = [

--- a/scripts/install-aladdin.sh
+++ b/scripts/install-aladdin.sh
@@ -15,5 +15,4 @@ CURRENT_VERSION=$(pipx list --json | jq -r .venvs.aladdin.metadata.main_package.
 
 if [[ ! "$ALADDIN_VERSION" == "$CURRENT_VERSION" ]]; then
     python3 -m pipx install git+https://github.com/fivestars-os/aladdin.git@${ALADDIN_VERSION} --force
-    exit 1
 fi

--- a/scripts/install-aladdin.sh
+++ b/scripts/install-aladdin.sh
@@ -5,6 +5,15 @@ curl -s https://api.github.com/repos/fivestars-os/aladdin/releases/latest | \
 python3 -c 'import json,sys;print(json.load(sys.stdin)["tag_name"])' || \
 echo -n "master")}
 
-python3 -m pip install --user --upgrade pipx
-python3 -m pipx ensurepath
-python3 -m pipx install git+https://github.com/fivestars-os/aladdin.git@${ALADDIN_VERSION} --force
+if ! command -v pipx &> /dev/null
+then
+    python3 -m pip install --user --upgrade pipx
+    python3 -m pipx ensurepath
+fi
+
+CURRENT_VERSION=$(pipx list --json | jq -r .venvs.aladdin.metadata.main_package.package_version)
+
+if [[ ! "$ALADDIN_VERSION" == "$CURRENT_VERSION" ]]; then
+    python3 -m pipx install git+https://github.com/fivestars-os/aladdin.git@${ALADDIN_VERSION} --force
+    exit 1
+fi


### PR DESCRIPTION
Trying to automatically inject `repo` values into the user aladdin config can result in a value with a duplicated prefix, example: `"plugin_repo": "git@github.com:git@github.com:fivestars/aladdin-plugins.git"`.

This PR adds a workaround to prevent that