### PR TITLE
Fix namespace creation label & hosted zone delegation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'master'
     tags:
-      - 'live'
       - '*.*.*'
       - '*.*.*.*'
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,17 +10,16 @@ RUN apt-get update && \
     curl
 
 RUN python -m venv /root/.venv
-ENV PATH /root/.venv/bin:$PATH
 
-ARG POETRY_VERSION=1.1.10
-ENV PATH /root/.local/bin:$PATH
+ENV PATH /root/.venv/bin:$PATH
+# also specified around line 45
+ARG POETRY_VERSION=1.1.12
 RUN pip install --upgrade pip && \
-    curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py -o install-poetry.py && \
-    python install-poetry.py --version $POETRY_VERSION
-ENV POETRY_VIRTUALENVS_CREATE="false"
-ENV POETRY_INSTALLER_PARALLEL="false"
+    pip install poetry==$POETRY_VERSION
+ARG POETRY_VIRTUALENVS_CREATE="false"
+ARG POETRY_INSTALLER_PARALLEL="false"
 # Poetry needs this to find the venv we created
-ENV VIRTUAL_ENV=/root/.venv
+ARG VIRTUAL_ENV=/root/.venv
 # Install aladdin python requirements
 COPY pyproject.toml poetry.lock ./
 RUN poetry install --no-root --no-dev
@@ -43,7 +42,10 @@ RUN apt-get update && \
     curl \
     ssh
 
-RUN pip install --no-cache-dir pip==21.2.4
+# also specified around line 15
+ARG POETRY_VERSION=1.1.12
+RUN pip install --upgrade pip && \
+    pip install poetry==$POETRY_VERSION
 
 # Update all needed tool versions here
 
@@ -83,12 +85,11 @@ RUN curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=
 
 WORKDIR /root/aladdin
 
-COPY --from=build /root/.local /root/.local
 COPY --from=build /root/.venv /root/.venv
-ENV PATH /root/.venv/bin:/root/.local/bin:$PATH
+ENV PATH /root/.venv/bin:$PATH
 # Install aladdin
 COPY . .
-ENV POETRY_VIRTUALENVS_CREATE="false"
+ARG POETRY_VIRTUALENVS_CREATE="false"
 # Poetry needs this to find the venv we created
-ENV VIRTUAL_ENV=/root/.venv
+ARG VIRTUAL_ENV=/root/.venv
 RUN poetry install --no-dev

--- a/aladdin/bash/container/create-namespace/create-namespace
+++ b/aladdin/bash/container/create-namespace/create-namespace
@@ -3,7 +3,9 @@ set -eu -o pipefail
 
 function create_namespace {
     kubectl create namespace $1
-    kubectl label --overwrite namespace $1 owner=$2 || true
+    if [ -z "$2" ]; then
+    	kubectl label --overwrite namespace $1 owner=$2 || true
+    fi
 }
 
 function usage {
@@ -15,7 +17,7 @@ function usage {
 		  owner                 the owner of the namespace (applied as a label)
 		                        ideally using the format First.Last
 		                        if not supplied then retrieved from `whoami`
-          
+
 		optional arguments:
 		  -h, --help            show this help message and exit
 	EOF
@@ -24,7 +26,7 @@ function usage {
 if [[ $# -eq 0 || "$1" == "-h" || "$1" == "--help" ]]; then
     usage
 elif [[ $# -eq 1 ]]; then
-	owner="$(aws sts get-caller-identity --query 'UserId' --output text | awk -F ':' '{print$2}' || echo nobody)"
+	owner="$(aws sts get-caller-identity --query 'UserId' --output text | awk -F ':' '{print$2}' || echo '')"
     create_namespace $1 $owner
 else
     create_namespace $@

--- a/aladdin/commands/cluster_init.py
+++ b/aladdin/commands/cluster_init.py
@@ -1,4 +1,4 @@
-from aladdin.lib.cluster_rules import cluster_rules
+from aladdin.lib.cluster_rules import ClusterRules
 from aladdin.commands import deploy
 from aladdin.lib.k8s.helm import Helm
 from aladdin.lib.arg_tools import container_command
@@ -28,8 +28,7 @@ def cluster_init_args(args):
 @container_command
 def cluster_init(force=False):
     helm = Helm()
-    cr = cluster_rules()
-    cluster_init_projects = cr.cluster_init
+    cluster_init_projects = ClusterRules().cluster_init
     for project in cluster_init_projects:
         project_name = project["project"]
         ref = project["ref"]

--- a/aladdin/commands/deploy.py
+++ b/aladdin/commands/deploy.py
@@ -7,7 +7,7 @@ import tempfile
 from aladdin.lib.arg_tools import (
     COMMON_OPTION_PARSER, HELM_OPTION_PARSER, CHART_OPTION_PARSER, container_command
 )
-from aladdin.lib.cluster_rules import cluster_rules
+from aladdin.lib.cluster_rules import ClusterRules
 from aladdin.commands import sync_ingress, sync_dns
 from aladdin.config import load_git_configs
 from aladdin.lib.helm_rules import HelmRules
@@ -69,7 +69,7 @@ def deploy(
     with tempfile.TemporaryDirectory() as tmpdirname:
         pr = PublishRules()
         helm = Helm()
-        cr = cluster_rules(namespace=namespace)
+        cr = ClusterRules(namespace=namespace)
         helm_chart_path = "{}/{}".format(tmpdirname, chart or project)
         hr = HelmRules(cr, chart or project)
         git_account = load_git_configs()["account"]

--- a/aladdin/commands/deploy.py
+++ b/aladdin/commands/deploy.py
@@ -7,6 +7,7 @@ import tempfile
 from aladdin.lib.arg_tools import (
     COMMON_OPTION_PARSER, HELM_OPTION_PARSER, CHART_OPTION_PARSER, container_command
 )
+from aladdin.lib.aws.certificate import get_cluster_certificate_arn, get_service_certificate_arn
 from aladdin.lib.cluster_rules import ClusterRules
 from aladdin.commands import sync_ingress, sync_dns
 from aladdin.config import load_git_configs
@@ -104,8 +105,8 @@ def deploy(
         }
         if cr.certificate_lookup:
             values.update({
-                "service.certificateArn": cr.get_service_certificate_arn(),
-                "service.clusterCertificateArn": cr.get_cluster_certificate_arn(),
+                "service.certificateArn": get_service_certificate_arn(),
+                "service.clusterCertificateArn": get_cluster_certificate_arn(),
             })
         # Update with cluster rule values
         values.update(cr.values)

--- a/aladdin/commands/get_certificate.py
+++ b/aladdin/commands/get_certificate.py
@@ -1,7 +1,7 @@
 import argparse
 import time
 
-from aladdin.lib.cluster_rules import cluster_rules
+from aladdin.lib.cluster_rules import ClusterRules
 from aladdin.lib.arg_tools import add_namespace_argument, container_command, expand_namespace
 
 
@@ -41,7 +41,7 @@ def get_certificate(
     wait: int = 0,
     poll_interval: int = 10
 ):
-    cr = cluster_rules(namespace=namespace)
+    cr = ClusterRules(namespace=namespace)
     cert = None
     timeout_start = time.time()
     while not cert:

--- a/aladdin/commands/get_certificate.py
+++ b/aladdin/commands/get_certificate.py
@@ -3,6 +3,7 @@ import time
 
 from aladdin.lib.cluster_rules import ClusterRules
 from aladdin.lib.arg_tools import add_namespace_argument, container_command, expand_namespace
+from aladdin.lib.aws.certificate import get_cluster_certificate_arn, get_service_certificate_arn
 
 
 def parse_args(parser):
@@ -46,9 +47,9 @@ def get_certificate(
     timeout_start = time.time()
     while not cert:
         if for_cluster:
-            cert = cr.get_cluster_certificate_arn()
+            cert = get_cluster_certificate_arn()
         else:
-            cert = cr.get_service_certificate_arn()
+            cert = get_service_certificate_arn()
         if not wait:
             return cert
         if wait > 0 and time.time() - timeout_start > wait:

--- a/aladdin/commands/namespace_init.py
+++ b/aladdin/commands/namespace_init.py
@@ -1,5 +1,5 @@
 from aladdin.lib.arg_tools import add_namespace_argument, container_command
-from aladdin.lib.cluster_rules import cluster_rules
+from aladdin.lib.cluster_rules import ClusterRules
 from aladdin.commands import deploy
 from aladdin.lib.k8s.helm import Helm
 
@@ -29,8 +29,7 @@ def namespace_init_args(args):
 @container_command
 def namespace_init(namespace, force=False):
     helm = Helm()
-    cr = cluster_rules(namespace=namespace)
-    namespace_init_projects = cr.namespace_init
+    namespace_init_projects = ClusterRules(namespace=namespace).namespace_init
     for project in namespace_init_projects:
         project_name = project["project"]
         ref = project["ref"]

--- a/aladdin/commands/rollback.py
+++ b/aladdin/commands/rollback.py
@@ -1,5 +1,5 @@
 from aladdin.lib.arg_tools import add_namespace_argument, container_command
-from aladdin.lib.cluster_rules import cluster_rules
+from aladdin.lib.cluster_rules import ClusterRules
 from aladdin.commands import sync_ingress, sync_dns
 from aladdin.lib.helm_rules import HelmRules
 from aladdin.lib.k8s.helm import Helm
@@ -26,8 +26,7 @@ def rollback_args(args):
 def rollback(project, num_versions, namespace, chart=None):
     helm = Helm()
 
-    cr = cluster_rules(namespace=namespace)
-    hr = HelmRules(cr, chart or project)
+    hr = HelmRules(ClusterRules(namespace=namespace), chart or project)
 
     helm.rollback_relative(hr, num_versions, namespace)
 

--- a/aladdin/commands/start.py
+++ b/aladdin/commands/start.py
@@ -4,6 +4,7 @@ import os
 from aladdin.lib.arg_tools import (
     COMMON_OPTION_PARSER, HELM_OPTION_PARSER, CHARTS_OPTION_PARSER, container_command
 )
+from aladdin.lib.aws.certificate import get_cluster_certificate_arn, get_service_certificate_arn
 from aladdin.lib.cluster_rules import ClusterRules
 from aladdin.commands import sync_ingress, sync_dns
 from aladdin.lib.helm_rules import HelmRules
@@ -64,8 +65,8 @@ def start(
     }
     if cr.certificate_lookup:
         values.update({
-            "service.certificateArn": cr.get_service_certificate_arn(),
-            "service.clusterCertificateArn": cr.get_cluster_certificate_arn(),
+            "service.certificateArn": get_service_certificate_arn(),
+            "service.clusterCertificateArn": get_cluster_certificate_arn(),
         })
     # Update with cluster rule values
     values.update(cr.values)

--- a/aladdin/commands/start.py
+++ b/aladdin/commands/start.py
@@ -4,7 +4,7 @@ import os
 from aladdin.lib.arg_tools import (
     COMMON_OPTION_PARSER, HELM_OPTION_PARSER, CHARTS_OPTION_PARSER, container_command
 )
-from aladdin.lib.cluster_rules import cluster_rules
+from aladdin.lib.cluster_rules import ClusterRules
 from aladdin.commands import sync_ingress, sync_dns
 from aladdin.lib.helm_rules import HelmRules
 from aladdin.lib.k8s.helm import Helm
@@ -44,7 +44,7 @@ def start(
     pc = ProjectConf()
     helm = Helm()
 
-    cr = cluster_rules(namespace=namespace)
+    cr = ClusterRules(namespace=namespace)
 
     if not charts:
         # Start each of the project's charts

--- a/aladdin/commands/stop.py
+++ b/aladdin/commands/stop.py
@@ -2,7 +2,7 @@
 import os
 
 from aladdin.lib.arg_tools import CHARTS_OPTION_PARSER, COMMON_OPTION_PARSER, container_command
-from aladdin.lib.cluster_rules import cluster_rules
+from aladdin.lib.cluster_rules import ClusterRules
 from aladdin.commands import sync_ingress, sync_dns
 from aladdin.lib.helm_rules import HelmRules
 from aladdin.lib.k8s.helm import Helm
@@ -26,7 +26,7 @@ def stop(namespace, charts):
     pc = ProjectConf()
     helm = Helm()
 
-    cr = cluster_rules(namespace=namespace)
+    cr = ClusterRules(namespace=namespace)
 
     if charts is None:
         # Stop each of the project's charts

--- a/aladdin/commands/sync_dns.py
+++ b/aladdin/commands/sync_dns.py
@@ -1,7 +1,7 @@
 import logging
 
 from aladdin.lib.arg_tools import add_namespace_argument, container_command
-from aladdin.lib.cluster_rules import cluster_rules
+from aladdin.lib.cluster_rules import ClusterRules
 from aladdin.lib.aws.dns_mapping import fill_hostedzone
 from aladdin.lib.k8s.kubernetes import Kubernetes
 from aladdin.lib.k8s.kubernetes_utils import KubernetesUtils
@@ -21,7 +21,7 @@ def sync_dns_args(args):
 
 @container_command
 def sync_dns(namespace):
-    cr = cluster_rules(namespace=namespace)
+    cr = ClusterRules(namespace=namespace)
     if cr.is_local:
         logging.info("Not syncing DNS because you are on local")
         return
@@ -40,9 +40,9 @@ def sync_dns(namespace):
 
     nb_updated = fill_hostedzone(
         cr.boto,
+        service_hostnames_to_loadbalancers,
         cr.cluster_domain_name,
         cr.namespace_domain_name,
-        service_hostnames_to_loadbalancers,
     )
 
     logging.info("%s DNS mapping updated" % (nb_updated or "No",))

--- a/aladdin/commands/sync_ingress.py
+++ b/aladdin/commands/sync_ingress.py
@@ -1,7 +1,7 @@
 import logging
 
 from aladdin.lib.arg_tools import add_namespace_argument, container_command
-from aladdin.lib.cluster_rules import cluster_rules
+from aladdin.lib.cluster_rules import ClusterRules
 from aladdin.lib.k8s.kubernetes import Kubernetes
 from aladdin.lib.k8s.ingress import build_ingress
 
@@ -20,7 +20,7 @@ def sync_ingress_args(args):
 
 @container_command
 def sync_ingress(namespace):
-    cr = cluster_rules(namespace=namespace)
+    cr = ClusterRules(namespace=namespace)
     ingress_info = cr.ingress_info
     if ingress_info and ingress_info["use_ingress_per_namespace"]:
         k = Kubernetes(namespace=namespace)

--- a/aladdin/commands/undeploy.py
+++ b/aladdin/commands/undeploy.py
@@ -1,5 +1,5 @@
 from aladdin.lib.arg_tools import add_namespace_argument, container_command
-from aladdin.lib.cluster_rules import cluster_rules
+from aladdin.lib.cluster_rules import ClusterRules
 from aladdin.commands import sync_ingress, sync_dns
 from aladdin.lib.helm_rules import HelmRules
 from aladdin.lib.k8s.helm import Helm
@@ -26,7 +26,7 @@ def undeploy_args(args):
 def undeploy(project, namespace, chart=None):
     helm = Helm()
 
-    cr = cluster_rules(namespace=namespace)
+    cr = ClusterRules(namespace=namespace)
     hr = HelmRules(cr, chart or project)
 
     helm.stop(hr, namespace)

--- a/aladdin/config.py
+++ b/aladdin/config.py
@@ -51,13 +51,18 @@ def load_config():
 
 
 def load_user_config() -> dict:
-    home = pathlib.Path.home()
-    return load_config_from_file(home / ".aladdin/config/config.json")
+    path = pathlib.Path.home() / ".aladdin/config/config.json"
+    try:
+        return load_config_from_file(path)
+    except FileNotFoundError:
+        set_user_config_file({})
+        return {}
 
 
 def set_user_config_file(config: dict):
-    home = pathlib.Path.home()
-    with open(home / ".aladdin/config/config.json", "w") as json_file:
+    path = pathlib.Path.home() / ".aladdin/config"
+    pathlib.Path(path).mkdir(parents=True, exist_ok=True)
+    with open(path / "config.json", "w") as json_file:
         json.dump(config, json_file, indent=2)
 
 

--- a/aladdin/lib/aws/certificate.py
+++ b/aladdin/lib/aws/certificate.py
@@ -5,7 +5,7 @@ import logging
 import re
 from hashlib import md5
 
-from aladdin.lib.aws.dns_mapping import create_hostedzone, fill_dns_dict, get_hostedzone
+from aladdin.lib.aws.dns_mapping import fill_hostedzone
 
 
 def search_certificate_arn(boto_session, dns_name):
@@ -20,7 +20,7 @@ def search_certificate_arn(boto_session, dns_name):
 
     certicate = _search_certificate(acm, dns_name, CertificateStatuses=["PENDING_VALIDATION"])
     if certicate:
-        _validate_certificate_with_retry(boto_session, dns_name, certicate)
+        _validate_certificate_with_retry(boto_session, certicate)
 
         # Warn that certificate is in pending state, so https will not work until certificate is
         # in issued state and project is redeployed
@@ -58,7 +58,7 @@ def new_certificate_arn(boto_session, dns_name):
         ],  # leave the default there
     )["CertificateArn"]
 
-    _validate_certificate_with_retry(boto_session, dns_name, arn)
+    _validate_certificate_with_retry(boto_session, arn)
 
     # Warn that certificate is in pending state yet, so https will not work until certificate is
     # in issued state and project is redeployed
@@ -71,20 +71,14 @@ def new_certificate_arn(boto_session, dns_name):
     return ""
 
 
-def _validate_certificate_with_retry(boto_session, dns_name, arn, max_retries=20):
+def _validate_certificate_with_retry(boto_session, arn, max_retries=20):
     """Validate new certificate using DNS validation"""
     log = logging.getLogger(__name__)
-
-    # Create the hosted zone for later dns validation
-    hostedzone_name = ".".join(dns_name.split(".")[1:])
-    hostedzone = get_hostedzone(boto_session, hostedzone_name) or create_hostedzone(
-        boto_session, hostedzone_name
-    )
-
     acm = boto_session.client("acm")
 
+    cname_record = None
     retry_count = 0
-    while retry_count < max_retries:
+    while not cname_record and retry_count < max_retries:
         try:
             cname_info = acm.describe_certificate(CertificateArn=arn)["Certificate"][
                 "DomainValidationOptions"
@@ -92,17 +86,17 @@ def _validate_certificate_with_retry(boto_session, dns_name, arn, max_retries=20
             cname_record = {cname_info["Name"][:-1]: cname_info["Value"]}
         except (KeyError, IndexError):
             retry_count += 1
-        else:
-            break
-    if retry_count == max_retries:
+
+    if cname_record:
+        # Create the hosted zone and add the cname used for dns validation
+        fill_hostedzone(boto_session, cname_record)
+    else:
         log.warning(
             f"Unable to validate certificate {arn} via DNS at this time. Please try again"
             " later by rerunning your aladdin command or by manually validating using the"
             " instructions here:"
             " https://github.com/fivestars/aladdin-fs/blob/master/doc/dns_and_certificate.md."
         )
-    else:
-        fill_dns_dict(boto_session, hostedzone, cname_record)
 
 
 def _search_certificate(client, domain_name, **filters):

--- a/aladdin/lib/aws/certificate.py
+++ b/aladdin/lib/aws/certificate.py
@@ -6,6 +6,7 @@ import re
 from hashlib import md5
 
 from aladdin.lib.aws.dns_mapping import fill_hostedzone
+from aladdin.lib.cluster_rules import ClusterRules
 
 
 def search_certificate_arn(boto_session, dns_name):
@@ -106,3 +107,22 @@ def _search_certificate(client, domain_name, **filters):
         for cert in page["CertificateSummaryList"]:
             if cert["DomainName"] == domain_name:
                 return cert["CertificateArn"]
+
+
+def get_service_certificate_arn(certificate_scope: str = None) -> str:
+    certificate_scope = certificate_scope or ClusterRules().service_certificate_scope
+    return _get_certificate_arn(certificate_scope)
+
+def get_cluster_certificate_arn(certificate_scope: str = None) -> str:
+    certificate_scope = certificate_scope or ClusterRules().cluster_certificate_scope
+    return _get_certificate_arn(certificate_scope)
+
+def _get_certificate_arn(certificate_scope) -> str:
+
+    cert = search_certificate_arn(ClusterRules().boto, certificate_scope)
+
+    # Check against None to allow empty string
+    if cert is None:
+        cert = new_certificate_arn(ClusterRules().boto, certificate_scope)
+
+    return cert

--- a/aladdin/lib/aws/dns_mapping.py
+++ b/aladdin/lib/aws/dns_mapping.py
@@ -2,11 +2,14 @@
 import logging
 from datetime import datetime
 
+from aladdin.lib.cluster_rules import ClusterRules
+
 
 def fill_hostedzone(
-    boto_session, cluster_domain_name, namespace_domain_name, hostnames_to_loadbalancers
+    boto_session, hostnames_to_loadbalancers, cluster_domain_name=None, namespace_domain_name=None
 ):
-    # Main DNS is on prod, sub DNS should be on sandbox
+    cluster_domain_name = cluster_domain_name or ClusterRules().cluster_domain_name
+    namespace_domain_name = namespace_domain_name or ClusterRules().namespace_domain_name
     namespace_hosted_zone = get_hostedzone(
         boto_session, namespace_domain_name
     ) or create_hostedzone(boto_session, namespace_domain_name)
@@ -22,7 +25,7 @@ def fill_hostedzone(
     return fill_dns_dict(boto_session, namespace_hosted_zone, hostnames_to_loadbalancers)
 
 
-def get_hostedzone(boto_session, dns_name):
+def get_hostedzone(boto_session, dns_name) -> str:
     log = logging.getLogger(__name__)
     route53 = boto_session.client("route53")
 
@@ -45,7 +48,7 @@ def get_hostedzone(boto_session, dns_name):
     return hostedzone_id
 
 
-def create_hostedzone(boto_session, dns_name):
+def create_hostedzone(boto_session, dns_name) -> str:
     log = logging.getLogger(__name__)
     route53 = boto_session.client("route53")
 

--- a/aladdin/lib/cluster_rules.py
+++ b/aladdin/lib/cluster_rules.py
@@ -4,12 +4,14 @@ from distutils.util import strtobool
 
 from aladdin.lib.arg_tools import CURRENT_NAMESPACE
 from aladdin.lib.aws.certificate import search_certificate_arn, new_certificate_arn
+from aladdin.lib.utils import singleton
 from aladdin.config import load_cluster_config, load_namespace_override_config
 
 
+@singleton
 class ClusterRules(object):
-    def __init__(self, rules, namespace=CURRENT_NAMESPACE):
-        self.rules = rules
+    def __init__(self, cluster=None, namespace=CURRENT_NAMESPACE):
+        self.rules = _cluster_rules(cluster=cluster, namespace=namespace)
         self._namespace = namespace
 
     def __getattr__(self, attr):
@@ -117,7 +119,7 @@ class ClusterRules(object):
         return boto3.Session(profile_name=self.aws_profile)
 
 
-def cluster_rules(cluster=None, namespace=CURRENT_NAMESPACE):
+def _cluster_rules(cluster=None, namespace=CURRENT_NAMESPACE) -> dict:
 
     if cluster is None:
         cluster = os.environ["CLUSTER_CODE"]
@@ -150,7 +152,7 @@ def cluster_rules(cluster=None, namespace=CURRENT_NAMESPACE):
     if allowed_namespaces != ["*"] and namespace not in allowed_namespaces:
         raise KeyError(f"Namespace {namespace} is not allowed on cluster {cluster}")
 
-    return ClusterRules(rules, namespace)
+    return rules
 
 
 def _update_rules(rules, override):

--- a/aladdin/lib/cluster_rules.py
+++ b/aladdin/lib/cluster_rules.py
@@ -1,6 +1,7 @@
 import os
 import boto3
 from distutils.util import strtobool
+from functools import cached_property
 
 from aladdin.lib.arg_tools import CURRENT_NAMESPACE
 from aladdin.lib.aws.certificate import search_certificate_arn, new_certificate_arn
@@ -114,7 +115,7 @@ class ClusterRules(object):
             return False
         return self.rules.get("certificate_lookup", True)
 
-    @property
+    @cached_property
     def boto(self):
         return boto3.Session(profile_name=self.aws_profile)
 

--- a/aladdin/lib/cluster_rules.py
+++ b/aladdin/lib/cluster_rules.py
@@ -4,7 +4,6 @@ from distutils.util import strtobool
 from functools import cached_property
 
 from aladdin.lib.arg_tools import CURRENT_NAMESPACE
-from aladdin.lib.aws.certificate import search_certificate_arn, new_certificate_arn
 from aladdin.lib.utils import singleton
 from aladdin.config import load_cluster_config, load_namespace_override_config
 
@@ -21,22 +20,6 @@ class ClusterRules(object):
         raise AttributeError(
             "'{}' object has no attribute '{}'".format(self.__class__.__name__, attr)
         )
-
-    def get_service_certificate_arn(self) -> str:
-        return self._get_certificate_arn(self.service_certificate_scope)
-
-    def get_cluster_certificate_arn(self) -> str:
-        return self._get_certificate_arn(self.cluster_certificate_scope)
-
-    def _get_certificate_arn(self, certificate_scope) -> str:
-
-        cert = search_certificate_arn(self.boto, certificate_scope)
-
-        # Check against None to allow empty string
-        if cert is None:
-            cert = new_certificate_arn(self.boto, certificate_scope)
-
-        return cert
 
     @property
     def cluster_certificate_scope(self):

--- a/aladdin/lib/utils.py
+++ b/aladdin/lib/utils.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+from typing import TypeVar
 
 
 @contextlib.contextmanager
@@ -14,3 +15,39 @@ def working_directory(path):
         yield
     finally:
         os.chdir(prev_cwd)
+
+
+Singleton = TypeVar("Singleton")
+
+
+def singleton(wrapped: Singleton) -> Singleton:
+    """Replace class with subclass whose constructor always returns the same instance"""
+
+    class wrapper(wrapped):
+        __instance = None
+        __initialized = False
+
+        def __new__(cls, *args, **kwargs):
+            # Only call the real constructor once.
+            if cls.__instance is None:
+                cls.__instance = super(wrapper, cls).__new__(cls)
+            return cls.__instance
+
+        def __init__(self, *args, **kwargs):
+            # Only initialize the instance once.
+            if not self.__initialized:
+                super(wrapper, self).__init__(*args, **kwargs)
+            self.__initialized = True
+
+        @classmethod
+        def singleton_reset_(cls):
+            cls.__instance = None
+            cls.__initialized = False
+
+    # Make sure the replacement class looks like the class it's replacing
+    wrapper.__module__ = wrapped.__module__
+    wrapper.__name__ = wrapped.__name__
+    if hasattr(wrapped, "__qualname__"):
+        wrapper.__qualname__ = wrapped.__qualname__
+
+    return wrapper

--- a/aladdin/main.py
+++ b/aladdin/main.py
@@ -125,17 +125,20 @@ def cli():
     if not sys.argv[1:] or sys.argv[1] in ["-h", "--help"]:
         return parser.print_help()
 
-    if not env.set_config_path():
+
+    cmd_args = list(filter(lambda arg: not arg.startswith("-"), sys.argv[1:]))
+    command = cmd_args[0] if cmd_args else None
+
+    if not env.set_config_path() and command != "config":
         return sys.exit(1)
     env.configure_env()
 
     # if it's not a command we know about it might be a plugin
     # currently the bash scripts handle plugins
-    cmd_args = list(filter(lambda arg: not arg.startswith("-"), sys.argv[1:]))
-    if not cmd_args or cmd_args[0] not in subparsers._name_parser_map:
+    if not command or command not in subparsers._name_parser_map:
         return bash_wrapper()
 
-    if cmd_args and cmd_args[0] in bash_command_names:
+    if command and command in bash_command_names:
         return bash_wrapper()
 
     args = parser.parse_args()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aladdin"
-version = "1.19.7.18"
+version = "1.19.7.19"
 description = ""
 authors = ["Fivestars <dev@fivestars.com>"]
 include = [

--- a/scripts/install-aladdin.sh
+++ b/scripts/install-aladdin.sh
@@ -5,7 +5,7 @@ curl -s https://api.github.com/repos/fivestars-os/aladdin/releases/latest | \
 python3 -c 'import json,sys;print(json.load(sys.stdin)["tag_name"])' || \
 echo -n "master")}
 
-if ! command -v pipx &> /dev/null
+if ! command -v pipx &> /dev/null || python3 -m pip list --outdated | grep pipx &> /dev/null
 then
     python3 -m pip install --user --upgrade pipx
     python3 -m pipx ensurepath


### PR DESCRIPTION
This PR fixes two bugs:
- `create-namespace` plugin throws an error when we are unable to get an owner using awscli
- A hosted zone is not setup correctly when it is created by the `get-certificate` command