### PR TITLE
Add backport for cached property

### DIFF
--- a/aladdin/lib/cluster_rules.py
+++ b/aladdin/lib/cluster_rules.py
@@ -4,6 +4,7 @@ from distutils.util import strtobool
 try:
     from functools import cached_property
 except ImportError:
+    # Running on pre-3.8 Python; use backport
     from backports.cached_property import cached_property
 
 from aladdin.lib.arg_tools import CURRENT_NAMESPACE

--- a/aladdin/lib/cluster_rules.py
+++ b/aladdin/lib/cluster_rules.py
@@ -1,7 +1,10 @@
 import os
 import boto3
 from distutils.util import strtobool
-from functools import cached_property
+try:
+    from functools import cached_property
+except ImportError:
+    from backports.cached_property import cached_property
 
 from aladdin.lib.arg_tools import CURRENT_NAMESPACE
 from aladdin.lib.utils import singleton

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aladdin"
-version = "1.19.7.19"
+version = "1.19.7.20"
 description = ""
 authors = ["Fivestars <dev@fivestars.com>"]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ jinja2 = "^2.11.2"
 lazy-object-proxy = "^1.5.1"
 urllib3 = "1.26.6"
 importlib-metadata = {version = "^1.0", python = "<3.8"}
+"backports.cached-property" = {version = "^1.0.1", python = "<3.8"}
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
This PR adds a fix for running aladdin in python < 3.8, `cached_property` was only added to `functools` until python 3.8, so we need a backport in order to support python 3.7