### PR TITLE
Add check for conflicting profiles in aws config

### DIFF
--- a/aladdin-container.sh
+++ b/aladdin-container.sh
@@ -187,8 +187,8 @@ function _handle_aws_config() {
         publish_profile="$(jq -r '.aws_profile' <<< $publish_config)"
         publish_role="$(jq -r '.aws_role_to_assume' <<< $publish_config)"
         publish_mfa_enabled="$(jq -r '.aws_role_mfa_required' <<< $publish_config)"
-        if aws configure list --profile "$publish_role" >/dev/null; then
-            echo "Conflicting AWS profile already exists: $publish_role; please check your ~/.aws/config and ~/.aws/credentials files"
+        if aws configure list --profile "$publish_profile" >/dev/null; then
+            echo "Conflicting AWS profile already exists: $publish_profile; please check your ~/.aws/config and ~/.aws/credentials files"
             exit 1
         fi
         "$add_assume_role_config" "$publish_role" "$publish_profile" "$publish_mfa_enabled" 3600 # 1 hour
@@ -196,8 +196,8 @@ function _handle_aws_config() {
         aws_profile="$(_extract_cluster_config_value bastion_account_profile_to_assume)"
         aws_role="$(_extract_cluster_config_value bastion_account_role_to_assume)"
         aws_mfa_enabled="$(_extract_cluster_config_value bastion_account_mfa_enabled)"
-        if aws configure list --profile "$aws_role" >/dev/null; then
-            echo "Conflicting AWS profile already exists: $aws_role; please check your ~/.aws/config and ~/.aws/credentials files"
+        if aws configure list --profile "$aws_profile" >/dev/null; then
+            echo "Conflicting AWS profile already exists: $aws_profile; please check your ~/.aws/config and ~/.aws/credentials files"
             exit 1
         fi
         "$add_assume_role_config" "$aws_role" "$aws_profile" "$aws_mfa_enabled" 3600 # 1 hour

--- a/aladdin-container.sh
+++ b/aladdin-container.sh
@@ -187,11 +187,19 @@ function _handle_aws_config() {
         publish_profile="$(jq -r '.aws_profile' <<< $publish_config)"
         publish_role="$(jq -r '.aws_role_to_assume' <<< $publish_config)"
         publish_mfa_enabled="$(jq -r '.aws_role_mfa_required' <<< $publish_config)"
+        if aws configure list --profile "$publish_role" >/dev/null; then
+            echo "Conflicting AWS profile already exists: $publish_role; please check your ~/.aws/config and ~/.aws/credentials files"
+            exit 1
+        fi
         "$add_assume_role_config" "$publish_role" "$publish_profile" "$publish_mfa_enabled" 3600 # 1 hour
         # Need to add aws configuration for current cluster's aws account
         aws_profile="$(_extract_cluster_config_value bastion_account_profile_to_assume)"
         aws_role="$(_extract_cluster_config_value bastion_account_role_to_assume)"
         aws_mfa_enabled="$(_extract_cluster_config_value bastion_account_mfa_enabled)"
+        if aws configure list --profile "$aws_role" >/dev/null; then
+            echo "Conflicting AWS profile already exists: $aws_role; please check your ~/.aws/config and ~/.aws/credentials files"
+            exit 1
+        fi
         "$add_assume_role_config" "$aws_role" "$aws_profile" "$aws_mfa_enabled" 3600 # 1 hour
         # We reset AWS_DEFAULT_PROFILE here because that entry will be present in aws config files now
         export AWS_DEFAULT_PROFILE="$aws_default_profile_temp"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aladdin"
-version = "1.19.7.22"
+version = "1.19.7.23"
 description = ""
 authors = ["Fivestars <dev@fivestars.com>"]
 include = [


### PR DESCRIPTION
This PR adds a small check to make sure the existing aws config does not already have a profile named like the one aladdin is trying to add