### PR TITLE
Fix deploy function when chart is not specified

### DIFF
--- a/aladdin/commands/deploy.py
+++ b/aladdin/commands/deploy.py
@@ -41,7 +41,7 @@ def deploy_args(args):
         args.project,
         args.git_ref,
         args.namespace,
-        args.chart or args.project,
+        args.chart,
         args.dry_run,
         args.force,
         args.force_helm,
@@ -64,6 +64,7 @@ def deploy(
     set_override_values=None,
     values_files=None
 ):
+    chart = chart or project
     if set_override_values is None:
         set_override_values = []
     with tempfile.TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
Small fix from after #122 , when the deploy function is called from `namespace_init()` or `cluster_init()` without specifying a chart