### PR TITLE
Fix missing "deploy.imageTag" value in start command

### DIFF
--- a/aladdin/commands/start.py
+++ b/aladdin/commands/start.py
@@ -54,6 +54,9 @@ def start(
     helm_args = []
     # Update with --set-override-values
     values.update(dict(value.split("=") for value in set_override_values))
+    values.update({
+        "deploy.imageTag": "local",
+    })
 
     try:
         for chart_path in pc.get_helm_chart_paths():

--- a/aladdin/commands/start.py
+++ b/aladdin/commands/start.py
@@ -52,11 +52,11 @@ def start(
 
     values = HelmRules.get_helm_values()
     helm_args = []
-    # Update with --set-override-values
-    values.update(dict(value.split("=") for value in set_override_values))
     values.update({
         "deploy.imageTag": "local",
     })
+    # Update with --set-override-values
+    values.update(dict(value.split("=") for value in set_override_values))
 
     try:
         for chart_path in pc.get_helm_chart_paths():


### PR DESCRIPTION
The "start" command/function is missing the `"deploy.imageTag"` value after #122 