### PR TITLE
Override "deploy.ecr" value in start command & use empty "SSH_AUTH_SOCK"

### DIFF
--- a/aladdin-container.sh
+++ b/aladdin-container.sh
@@ -88,7 +88,7 @@ function environment_init() {
     # Make sure we are on local or that cluster has been created before creating namespaces, etc
     if _is_cluster_ready; then
         # If we're doing ssh-agent forwarding add a dummy ssh config
-        if [ ! -f $HOME/.ssh/config ] && [ ! -z "$SSH_AUTH_SOCK" ]
+        if [ ! -f $HOME/.ssh/config ] && [ ! -z "${SSH_AUTH_SOCK:-}" ]
         then
             mkdir -p $HOME/.ssh/
             git config --global url.ssh://git@github.com/.insteadOf https://github.com/

--- a/aladdin/commands/start.py
+++ b/aladdin/commands/start.py
@@ -54,6 +54,7 @@ def start(
     helm_args = []
     values.update({
         "deploy.imageTag": "local",
+        "deploy.ecr": "",
     })
     # Update with --set-override-values
     values.update(dict(value.split("=") for value in set_override_values))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aladdin"
-version = "1.19.7.24"
+version = "1.19.7.25"
 description = ""
 authors = ["Fivestars <dev@fivestars.com>"]
 include = [


### PR DESCRIPTION
This PR fixes the missing "deploy.ecr" value override in the "start" command
Additionally it fixes the usage of the "SSH_AUTH_SOCK" env var which may not always be set