### PR TITLE
Add support for multiple values file paths

### DIFF
--- a/aladdin/commands/deploy.py
+++ b/aladdin/commands/deploy.py
@@ -80,7 +80,7 @@ def deploy(
         if not force and cr.check_branch and Git.extract_hash("HEAD", git_url) != git_ref:
             logging.error(
                 f"You are deploying hash {git_ref} which does not match default branch"
-                f" on cluster {cr.cluster_name} for project {project}... exiting"
+                f" on cluster {cr.cluster_domain_name} for project {project}... exiting"
             )
             sys.exit(1)
 
@@ -102,7 +102,7 @@ def deploy(
         helm.upgrade(
             HelmRules.get_release_name(chart),
             helm_chart_path,
-            cr.cluster_name,
+            cr.values_files,
             namespace,
             force=force_helm,
             dry_run=dry_run,

--- a/aladdin/commands/helm_values.py
+++ b/aladdin/commands/helm_values.py
@@ -93,7 +93,7 @@ def helm_values(
             command = Helm().prepare_command(
                 command,
                 chart_path,
-                ClusterRules().cluster_name,
+                ClusterRules().values_files,
                 ClusterRules().namespace,
                 helm_args=["--set-string", f"deploy.imageTag={git_ref}"],
                 **HelmRules.get_helm_values(),

--- a/aladdin/commands/start.py
+++ b/aladdin/commands/start.py
@@ -69,7 +69,7 @@ def start(
             if chart_name in charts:
                 release_name = HelmRules.get_release_name(chart_name)
                 helm.upgrade(
-                    release_name, chart_path, cr.cluster_name, namespace,
+                    release_name, chart_path, cr.values_files, namespace,
                     force=force_helm, dry_run=dry_run, helm_args=helm_args, **values
                 )
     finally:

--- a/aladdin/lib/cluster_rules.py
+++ b/aladdin/lib/cluster_rules.py
@@ -1,6 +1,7 @@
 import os
 import boto3
 from distutils.util import strtobool
+from typing import List
 try:
     from functools import cached_property
 except ImportError:
@@ -48,7 +49,7 @@ class ClusterRules(object):
         return self.rules.get("service_dns_suffix", self.namespace_domain_name)
 
     @property
-    def cluster_domain_name(self):
+    def cluster_domain_name(self) -> str:
         """
         Alias to aladdin "root_dns" config value.
 
@@ -56,6 +57,15 @@ class ClusterRules(object):
         more appropriate terminology here in the code.
         """
         return self.root_dns
+
+    @property
+    def values_files(self) -> List[str]:
+        """
+        Alias to aladdin "values_files" config value.
+
+        Defaults to aladdin "cluster_name" config value for backwards compatibility
+        """
+        return self.rules.get("values_files", [self.cluster_name])
 
     @property
     def namespace_domain_name(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aladdin"
-version = "1.19.7.33"
+version = "1.19.7.34"
 description = ""
 authors = ["Fivestars <dev@fivestars.com>"]
 include = [


### PR DESCRIPTION
This PR enables a new aladdin config option called `values_files`.

This new option will allow clusters to declare a list of values files that should be picked up from a project helm chart, previously this was inferred from the `cluster_name` config option.