### PR TITLE
Fix `ALADDIN_CONFIG_DIR` not set

### DIFF
--- a/aladdin.sh
+++ b/aladdin.sh
@@ -27,6 +27,9 @@ source "$SCRIPT_DIR/shared.sh"
 
 # Check for cluster name aliases and alias them accordingly
 function check_cluster_alias() {
+    if [[ -z "${ALADDIN_CONFIG_DIR:-}" ]]; then
+        return 0
+    fi
     cluster_alias=$(jq -r --arg key "$CLUSTER_CODE" '.cluster_aliases[$key]' "$ALADDIN_CONFIG_DIR/config.json")
     if [[ $cluster_alias != null ]]; then
         export CLUSTER_CODE=$cluster_alias

--- a/scripts/shared.sh
+++ b/scripts/shared.sh
@@ -8,6 +8,9 @@ function _extract_cluster_config_value() {
     # Try extracting config from cluster config.json, default config.json, then aladdin config.json
     local value
     value="$1"
+    if [[ -z "${ALADDIN_CONFIG_DIR:-}" ]]; then
+        return 0
+    fi
     jq -nr --arg value "$value" 'first(inputs | (if .[$value] == null then empty else .[$value] end))' \
         "$ALADDIN_CONFIG_DIR/$CLUSTER_CODE/config.json" "$ALADDIN_CONFIG_DIR/default/config.json" \
         "$ALADDIN_CONFIG_DIR/config.json"


### PR DESCRIPTION
This PR adds graceful handling of `ALADDIN_CONFIG_DIR` not being set in some of the initialization scripts in aladdin

Closes: #143 