### PR TITLE
feat: Add support for value overlays

### DIFF
--- a/aladdin/charts/merger/templates/values.yaml
+++ b/aladdin/charts/merger/templates/values.yaml
@@ -1,1 +1,10 @@
-{{- toYaml .Values -}}
+{{- $overLay := get .Values "aladdin.overlay" }}
+{{- $values := unset .Values "aladdin.overlay" }}
+{{- if $overLay }}
+{{/* Enable the injection of render values into other values */}}
+{{- $overLay = tpl (toYaml ($overLay | default "")) (dict "Values" $values) }}
+{{- $overLay = fromYaml $overLay }}
+{{- toYaml (merge $values $overLay) }}
+{{- else }}
+{{- toYaml $values }}
+{{- end }}

--- a/aladdin/lib/publish_rules.py
+++ b/aladdin/lib/publish_rules.py
@@ -9,5 +9,4 @@ class PublishRules:
     def __init__(self):
         publish_configs = load_publish_configs()
         boto = boto3.Session(profile_name=publish_configs["aws_profile"])
-        self.docker_registry = publish_configs["docker_ecr_repo"]
         self.ecr = boto.client("ecr")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aladdin"
-version = "1.29.8.0"
+version = "1.29.8.1"
 description = ""
 authors = ["Fivestars <dev@fivestars.com>"]
 include = [


### PR DESCRIPTION
This PR adds support for injecting dynamic values into other existing values for a helm chart.

For example this input values file
```yaml
tags:
  owner: me

deploy:
  imageTag: v1.0.0

aladdin.overlay:
  tags:
    imageTag: "{{ .Values.deploy.imageTag }}"
```

would get transformed into:
```yaml
tags:
  owner: me
  imageTag: v1.0.0
```