### PR TITLE
feat: Add support for image tag injection

### DIFF
--- a/aladdin/commands/helm_values.py
+++ b/aladdin/commands/helm_values.py
@@ -98,13 +98,17 @@ def helm_values(
             if all_values:
                 command.append(f"--values={chart_path}/values.yaml")
 
+            helm_args = []
+            for alias in ProjectConf().get_image_tag_aliases():
+                # We need to use --set-string in case the git ref is all digits
+                helm_args.extend("--set-string", f"{alias}={git_ref}")
+
             command = Helm().prepare_command(
                 command,
                 chart_path,
                 ClusterRules(namespace=namespace).values_files,
                 ClusterRules(namespace=namespace).namespace,
-                # We need to use --set-string in case the git ref is all digits
-                helm_args=["--set-string", f"deploy.imageTag={git_ref}"],
+                helm_args=helm_args,
                 **HelmRules.get_helm_values(),
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aladdin"
-version = "1.30.10.4"
+version = "1.30.10.5"
 description = ""
 authors = ["Fivestars <dev@fivestars.com>"]
 


### PR DESCRIPTION
This PR adds new optional functionality to inject the `deploy.imageTag` value into new helm value locations depending on chart needs

The functionality can be turned on by adding `globalImageTag` to the lamp.json or by specifying a list of aliases as `imageTagAlias` in lamp.json