### PR TITLE
fix: Update tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,7 @@ jobs:
           script: |
             const tags = `${{ steps.meta.outputs.tags }}`.split('\n')
 
-            return tags.map((tag) => `--tag ${tag}`)
+            return tags.map((tag) => `--tag ${tag}`).join(' ')
 
       - name: werf publish
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aladdin"
-version = "1.30.10.5"
+version = "1.30.10.6"
 description = ""
 authors = ["Fivestars <dev@fivestars.com>"]
 


### PR DESCRIPTION
Current version does separation by comma: `--tag index.docker.io/fivestarsos/aladdin:1.30.10.5,--tag index.docker.io/fivestarsos/aladdin:latest` , but we need by space:
`--tag index.docker.io/fivestarsos/aladdin:1.30.10.5 --tag index.docker.io/fivestarsos/aladdin:latest`